### PR TITLE
feat: add aiup-compose-ktor-exposed plugin for KMP stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,16 @@ marketplace/
 │       ├── implement/
 │       ├── karibu-test/
 │       └── playwright-test/
+├── aiup-compose-ktor-exposed/    # Kotlin KMP + Compose + Ktor + Exposed stack plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   ├── .mcp.json                 # KotlinDocs (javadocs.dev)
+│   └── skills/                   # All workflow steps as skills (slash commands)
+│       ├── flyway-migration/
+│       ├── implement/
+│       ├── implement-ui/
+│       ├── ktor-test/
+│       └── compose-test/
 └── README.md
 ```
 
@@ -41,7 +51,8 @@ marketplace/
 ### Two-Layer Design
 
 - **aiup-core** — Stack-agnostic methodology: from vision to use case specification. Works with any tech stack.
-- **vaadin-jooq** — Stack-specific: implementation and testing for the Vaadin + jOOQ stack. Requires core.
+- **aiup-vaadin-jooq** — Stack-specific: implementation and testing for the Vaadin + jOOQ stack. Requires core.
+- **aiup-compose-ktor-exposed** — Stack-specific: implementation and testing for the Kotlin KMP + Compose + Ktor + Exposed stack. Requires core.
 
 ### Marketplace Configuration
 
@@ -78,3 +89,13 @@ Skills follow the AI Unified Process phases: Inception, Elaboration, Constructio
 | Construction | `/browserless-test`   | Create Vaadin Browserless unit tests (recommended)       |
 | Construction | `/karibu-test`        | Create Karibu unit tests (legacy — superseded since 25.1) |
 | Construction | `/playwright-test`    | Create Playwright integration tests                      |
+
+### Compose/Ktor/Exposed (stack-specific)
+
+| Phase        | Skill (slash command) | Description                                              |
+|--------------|-----------------------|----------------------------------------------------------|
+| Construction | `/flyway-migration`   | Create Flyway PostgreSQL migrations from entity model    |
+| Construction | `/implement`          | Implement backend: shared DTOs + Exposed DSL + Ktor routes |
+| Construction | `/implement-ui`       | Implement UI: Compose Multiplatform screens + Ktor Client  |
+| Construction | `/ktor-test`          | Create Ktor testApplication API tests                    |
+| Construction | `/compose-test`       | Create Compose UI tests with runComposeUiTest            |

--- a/aiup-compose-ktor-exposed/.claude-plugin/plugin.json
+++ b/aiup-compose-ktor-exposed/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "aiup-compose-ktor-exposed",
+  "description": "AI Unified Process plugin for the Kotlin Multiplatform / Compose / Ktor / Exposed stack",
+  "version": "1.0.0",
+  "author": {
+    "name": "Stephan Leicht Vogt",
+    "email": "stephan@fanaka.ch",
+    "url": "https://github.com/sleicht"
+  }
+}

--- a/aiup-compose-ktor-exposed/.mcp.json
+++ b/aiup-compose-ktor-exposed/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "KotlinDocs": {
+      "type": "http",
+      "url": "https://www.javadocs.dev/mcp"
+    }
+  }
+}

--- a/aiup-compose-ktor-exposed/skills/compose-test/SKILL.md
+++ b/aiup-compose-ktor-exposed/skills/compose-test/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: compose-test
+description: >
+  Creates Compose Multiplatform UI tests using runComposeUiTest with
+  semantics-based assertions covering screen rendering, user interactions,
+  form validation, navigation, and state management. Use when the user asks
+  to "write Compose tests", "test the UI", "create screen tests", "unit test
+  a Compose screen", or mentions Compose testing, UI testing,
+  runComposeUiTest, semantics testing, or Compose assertions.
+---
+
+# Compose Test
+
+## Instructions
+
+Create Compose Multiplatform UI tests for use case $ARGUMENTS using:
+- `runComposeUiTest {}` for in-process UI testing (no device or emulator needed)
+- Semantics-based node finders (`onNodeWithText`, `onNodeWithContentDescription`)
+- kotlin.test for test annotations
+- Kotest assertions where applicable
+
+## DO NOT
+
+- Use Android-specific `createComposeRule()` (use `runComposeUiTest` for multiplatform)
+- Use `Thread.sleep()` or explicit delays (use `waitUntil {}` for async operations)
+- Make real network calls (provide fake/stub API clients)
+- Test implementation details (test behavior through the semantics tree)
+- Use `onNodeWithTag` as the primary finder (prefer text and content description for accessibility)
+
+## Test Data Strategy
+
+Provide fake API clients that return predefined data. Do not call real backends.
+
+```kotlin
+class FakePersonApiClient : PersonApiClient {
+    val persons = mutableListOf(
+        PersonDto(id = 1, firstName = "Eula", lastName = "Lane", email = "eula@example.com"),
+        PersonDto(id = 2, firstName = "John", lastName = "Doe", email = "john@example.com")
+    )
+
+    override suspend fun getAll(): List<PersonDto> = persons
+    override suspend fun getById(id: Long): PersonDto = persons.first { it.id == id }
+    override suspend fun create(dto: PersonDto): PersonDto = dto.copy(id = 3)
+    override suspend fun update(id: Long, dto: PersonDto): PersonDto = dto.copy(id = id)
+    override suspend fun delete(id: Long) { persons.removeAll { it.id == id } }
+}
+```
+
+## Template
+
+Use [templates/ExampleScreenTest.kt](templates/ExampleScreenTest.kt) as the test class structure.
+
+## Common Patterns
+
+### Basic Test Setup
+
+```kotlin
+class PersonListScreenTest {
+
+    private val fakeClient = FakePersonApiClient()
+
+    @Test
+    fun screen_displays_persons() = runComposeUiTest {
+        setContent {
+            PersonListScreen(
+                apiClient = fakeClient,
+                onPersonClick = {},
+                onAddClick = {}
+            )
+        }
+
+        onNodeWithText("Eula Lane").assertIsDisplayed()
+        onNodeWithText("John Doe").assertIsDisplayed()
+    }
+}
+```
+
+### Finding Nodes
+
+```kotlin
+// By visible text
+onNodeWithText("Save").assertIsDisplayed()
+onNodeWithText("Eula", substring = true).assertExists()
+
+// By content description (icons, image buttons)
+onNodeWithContentDescription("Add Person").assertIsDisplayed()
+onNodeWithContentDescription("Back").performClick()
+
+// By test tag (when text/description aren't suitable)
+onNodeWithTag("person-grid").assertIsDisplayed()
+
+// Multiple matching nodes
+onAllNodesWithText("Delete").assertCountEquals(2)
+onAllNodesWithText("Delete")[0].performClick()
+```
+
+### User Interactions
+
+```kotlin
+// Click
+onNodeWithText("Save").performClick()
+
+// Text input
+onNodeWithText("First Name").performTextInput("John")
+onNodeWithText("First Name").performTextClearance()
+onNodeWithText("First Name").performTextReplacement("Jane")
+
+// Scroll
+onNodeWithTag("person-list").performScrollToIndex(10)
+onNodeWithText("Last Item").performScrollTo()
+
+// Swipe
+onNodeWithTag("item-1").performTouchInput { swipeLeft() }
+```
+
+### Assertions
+
+```kotlin
+// Visibility
+onNodeWithText("Save").assertIsDisplayed()
+onNodeWithText("Error").assertDoesNotExist()
+
+// Enabled state
+onNodeWithText("Save").assertIsEnabled()
+onNodeWithText("Save").assertIsNotEnabled()
+
+// Focus
+onNodeWithText("First Name").assertIsFocused()
+
+// Text content
+onNodeWithText("First Name").assertTextEquals("First Name", "John")
+onNodeWithText("First Name").assertTextContains("John")
+
+// Selection
+onNodeWithText("Active").assertIsOn()     // checkbox/switch
+onNodeWithText("Active").assertIsOff()
+
+// Count
+onAllNodesWithText("Delete").assertCountEquals(5)
+onAllNodesWithContentDescription("Star").assertCountEquals(3)
+```
+
+### Waiting for Async Operations
+
+```kotlin
+@Test
+fun screen_shows_data_after_loading() = runComposeUiTest {
+    setContent {
+        PersonListScreen(apiClient = fakeClient, onPersonClick = {}, onAddClick = {})
+    }
+
+    // Wait for loading to complete
+    waitUntil(timeoutMillis = 5000) {
+        onAllNodesWithText("Eula").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithText("Eula Lane").assertIsDisplayed()
+}
+```
+
+### Testing Navigation Callbacks
+
+```kotlin
+@Test
+fun clicking_person_triggers_navigation() = runComposeUiTest {
+    var navigatedToId: Long? = null
+
+    setContent {
+        PersonListScreen(
+            apiClient = fakeClient,
+            onPersonClick = { navigatedToId = it },
+            onAddClick = {}
+        )
+    }
+
+    waitUntil {
+        onAllNodesWithText("Eula").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithText("Eula Lane").performClick()
+
+    navigatedToId shouldBe 1L
+}
+```
+
+### Testing Form Validation
+
+```kotlin
+@Test
+fun empty_name_shows_error() = runComposeUiTest {
+    setContent {
+        PersonDetailScreen(personId = null, onNavigateBack = {})
+    }
+
+    // Leave name empty, click save
+    onNodeWithText("Save").performClick()
+
+    // Assert error is shown
+    onNodeWithText("First name is required").assertIsDisplayed()
+}
+```
+
+### Testing Snackbar / Feedback
+
+```kotlin
+@Test
+fun save_success_shows_snackbar() = runComposeUiTest {
+    setContent {
+        PersonDetailScreen(personId = null, onNavigateBack = {})
+    }
+
+    onNodeWithText("First Name").performTextInput("John")
+    onNodeWithText("Last Name").performTextInput("Doe")
+    onNodeWithText("Email").performTextInput("john@example.com")
+    onNodeWithText("Save").performClick()
+
+    waitUntil {
+        onAllNodesWithText("Saved successfully").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("Saved successfully").assertIsDisplayed()
+}
+```
+
+## Assertions Reference
+
+| Assertion Type       | Example                                                |
+|----------------------|--------------------------------------------------------|
+| Displayed            | `onNodeWithText("Name").assertIsDisplayed()`           |
+| Not exists           | `onNodeWithText("Error").assertDoesNotExist()`         |
+| Enabled              | `onNodeWithText("Save").assertIsEnabled()`             |
+| Disabled             | `onNodeWithText("Save").assertIsNotEnabled()`          |
+| Text content         | `onNodeWithText("Name").assertTextContains("John")`    |
+| Checkbox on          | `onNodeWithText("Active").assertIsOn()`                |
+| Count                | `onAllNodesWithText("Item").assertCountEquals(3)`      |
+| Callback triggered   | `navigatedToId shouldBe 1L` (Kotest)                  |
+
+## Build Tool Discovery
+
+- Check for `.mise.toml` in the project root. If present, use `mise run test` (or the equivalent task name).
+- If no mise configuration exists, fall back to `./gradlew desktopTest` (or the appropriate test task for the UI module).
+
+## Workflow
+
+1. Read the use case specification
+2. Use TodoWrite to create a task for each test scenario
+3. Create a fake API client for the screen under test
+4. Create test class using the template
+5. For each test:
+    - Set content with the composable under test, injecting fakes
+    - Find nodes using semantics (text, content description)
+    - Perform interactions (click, text input, scroll)
+    - Assert expected outcomes
+    - Use `waitUntil` for any async operations
+6. Run tests to verify they pass
+7. If a test fails:
+    - Use `onRoot().printToLog("TAG")` to dump the semantics tree
+    - Verify the composable is receiving the fake data correctly
+    - Check that `waitUntil` timeouts are sufficient
+    - Ensure text matchers are exact (use `substring = true` for partial matches)
+8. Mark todos complete
+
+## Resources
+
+- Use the KotlinDocs MCP server for Compose testing API reference

--- a/aiup-compose-ktor-exposed/skills/compose-test/templates/ExampleScreenTest.kt
+++ b/aiup-compose-ktor-exposed/skills/compose-test/templates/ExampleScreenTest.kt
@@ -1,0 +1,114 @@
+package com.example.app.ui
+
+import com.example.app.model.PersonDto
+import io.kotest.matchers.shouldBe
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ExampleScreenTest {
+
+    private val fakeClient = FakePersonApiClient()
+
+    @Test
+    fun screen_displays_persons() = runComposeUiTest {
+        setContent {
+            PersonListScreen(
+                apiClient = fakeClient,
+                onPersonClick = {},
+                onAddClick = {}
+            )
+        }
+
+        waitUntil(timeoutMillis = 5000) {
+            onAllNodesWithText("Eula").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        onNodeWithText("Eula Lane").assertIsDisplayed()
+        onNodeWithText("John Doe").assertIsDisplayed()
+    }
+
+    @Test
+    fun clicking_person_triggers_navigation() = runComposeUiTest {
+        var navigatedToId: Long? = null
+
+        setContent {
+            PersonListScreen(
+                apiClient = fakeClient,
+                onPersonClick = { navigatedToId = it },
+                onAddClick = {}
+            )
+        }
+
+        waitUntil(timeoutMillis = 5000) {
+            onAllNodesWithText("Eula").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        onNodeWithText("Eula Lane").performClick()
+
+        navigatedToId shouldBe 1L
+    }
+
+    @Test
+    fun add_button_triggers_callback() = runComposeUiTest {
+        var addClicked = false
+
+        setContent {
+            PersonListScreen(
+                apiClient = fakeClient,
+                onPersonClick = {},
+                onAddClick = { addClicked = true }
+            )
+        }
+
+        onNodeWithContentDescription("Add Person").performClick()
+
+        addClicked shouldBe true
+    }
+
+    @Test
+    fun form_saves_new_person() = runComposeUiTest {
+        var navigatedBack = false
+
+        setContent {
+            PersonDetailScreen(
+                personId = null,
+                onNavigateBack = { navigatedBack = true }
+            )
+        }
+
+        onNodeWithText("First Name").performTextInput("Jane")
+        onNodeWithText("Last Name").performTextInput("Smith")
+        onNodeWithText("Email").performTextInput("jane@example.com")
+
+        onNodeWithText("Save").performClick()
+
+        waitUntil(timeoutMillis = 5000) { navigatedBack }
+
+        navigatedBack shouldBe true
+    }
+
+    // -- Fake API Client -------------------------------------------------------
+
+    class FakePersonApiClient : PersonApiClient {
+        val persons = mutableListOf(
+            PersonDto(id = 1, firstName = "Eula", lastName = "Lane", email = "eula@example.com"),
+            PersonDto(id = 2, firstName = "John", lastName = "Doe", email = "john@example.com")
+        )
+
+        override suspend fun getAll(): List<PersonDto> = persons
+        override suspend fun getById(id: Long): PersonDto = persons.first { it.id == id }
+        override suspend fun create(dto: PersonDto): PersonDto = dto.copy(id = 3)
+        override suspend fun update(id: Long, dto: PersonDto): PersonDto = dto.copy(id = id)
+        override suspend fun delete(id: Long) { persons.removeAll { it.id == id } }
+    }
+}

--- a/aiup-compose-ktor-exposed/skills/flyway-migration/SKILL.md
+++ b/aiup-compose-ktor-exposed/skills/flyway-migration/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: flyway-migration
+description: >
+  Creates versioned Flyway database migration scripts (V*.sql) for PostgreSQL
+  with sequences, tables, constraints, and foreign keys from the entity model.
+  Use when the user asks to "create a migration", "generate SQL scripts",
+  "set up database tables", "write a Flyway migration", or mentions schema
+  migration, DB migration, database versioning, or SQL migration files.
+---
+
+# Flyway Migration
+
+## Instructions
+
+Create Flyway database migration scripts for PostgreSQL based on `docs/entity_model.md`.
+Use sequences for primary keys.
+
+## DO NOT
+
+- Use auto-increment or `SERIAL` for primary keys (use sequences instead)
+- Create migrations that drop existing tables without explicit user confirmation
+- Skip foreign key constraints defined in the entity model
+- Use database-specific features not supported by PostgreSQL
+
+## File Naming Convention
+
+Flyway versioned migrations follow this naming pattern:
+
+```
+V001__create_room_type_table.sql
+V002__create_guest_table.sql
+V003__create_reservation_table.sql
+```
+
+## Example Migration
+
+```sql
+-- V001__create_room_type_table.sql
+
+CREATE SEQUENCE room_type_seq START WITH 1 INCREMENT BY 1 CACHE 50;
+
+CREATE TABLE room_type
+(
+    id          BIGINT DEFAULT nextval('room_type_seq') PRIMARY KEY,
+    name        VARCHAR(50)    NOT NULL UNIQUE,
+    description VARCHAR(500),
+    capacity    INTEGER        NOT NULL CHECK (capacity BETWEEN 1 AND 10),
+    price       DECIMAL(10, 2) NOT NULL CHECK (price >= 0)
+);
+```
+
+## Corresponding Exposed Table Object
+
+When creating a migration, also document the matching Exposed DSL table definition
+that should be created in the server module:
+
+```kotlin
+object RoomTypes : LongIdTable("room_type") {
+    val name = varchar("name", 50).uniqueIndex()
+    val description = varchar("description", 500).nullable()
+    val capacity = integer("capacity").check { it.between(1, 10) }
+    val price = decimal("price", 10, 2).check { it greaterEq BigDecimal.ZERO }
+}
+```
+
+## Build Tool Discovery
+
+- Check for `.mise.toml` in the project root. If present, use `mise run migrate` (or the equivalent task name).
+- If no mise configuration exists, fall back to `./gradlew flywayMigrate` or the project's Gradle task.
+
+## Workflow
+
+1. Read `docs/entity_model.md`
+2. Read existing migrations to determine the next version number
+3. Create sequence definitions for each entity
+4. Create table definitions with columns, constraints, and foreign keys
+5. Order tables so that referenced tables are created before referencing tables
+6. Validate the migration:
+    - Verify all entities from the entity model have corresponding tables
+    - Verify all foreign keys reference tables that are created in the same or earlier migration
+    - Verify sequence names follow the pattern `{table_name}_seq`
+    - Verify the SQL syntax is valid for PostgreSQL
+
+## Resources
+
+- Use the KotlinDocs MCP server for Exposed table DSL reference

--- a/aiup-compose-ktor-exposed/skills/implement-ui/SKILL.md
+++ b/aiup-compose-ktor-exposed/skills/implement-ui/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: implement-ui
+description: >
+  Implements Compose Multiplatform screens and wires them to the Ktor backend
+  via Ktor Client using shared @Serializable DTOs. Use when the user asks to
+  "implement the UI", "create a screen", "build the Compose view", "wire the
+  frontend", or mentions Compose Multiplatform screen, UI implementation,
+  client-side development, or frontend for a use case.
+---
+
+# Implement Use Case (UI)
+
+## Instructions
+
+Implement the Compose Multiplatform UI for use case $ARGUMENTS using:
+- Compose Multiplatform screens with Material 3 components
+- Ktor Client for API calls to the backend
+- Shared `@Serializable` DTOs from `commonMain`
+- Koin for dependency injection
+
+Don't create tests -- there is the `compose-test` skill for that.
+Don't create backend code -- there is the `implement` skill for that.
+
+## Prerequisites
+
+The backend must be implemented first (shared DTOs, Ktor routes, Exposed repositories).
+The `@Serializable` DTOs in `commonMain` must exist before building the UI.
+
+## DO NOT
+
+- Create test classes (use `compose-test` instead)
+- Create backend code (use `implement` instead)
+- Duplicate DTO definitions (import from `commonMain`)
+- Use platform-specific APIs without `expect`/`actual` declarations
+- Block the UI thread with synchronous network calls
+- Use `runBlocking` in composables (use `LaunchedEffect` or ViewModel coroutine scopes)
+
+## Architecture Layers
+
+```
+commonMain/
+  └── model/              # @Serializable DTOs (already created by /implement)
+      └── PersonDto.kt
+
+UI module (composeApp / shared):
+  ├── data/
+  │   └── PersonApiClient.kt    # Ktor Client calls
+  ├── ui/
+  │   ├── PersonListScreen.kt   # List/overview screen
+  │   └── PersonDetailScreen.kt # Detail/edit screen
+  └── di/
+      └── UiModule.kt           # Koin module for UI dependencies
+```
+
+> **Note:** The actual package/directory structure must be discovered from the existing project.
+> The above is a reference pattern -- always follow existing conventions.
+
+## API Client Pattern
+
+```kotlin
+// In the UI module (commonMain or composeApp)
+class PersonApiClient(private val httpClient: HttpClient) {
+    suspend fun getAll(): List<PersonDto> =
+        httpClient.get("/api/persons").body()
+
+    suspend fun getById(id: Long): PersonDto =
+        httpClient.get("/api/persons/$id").body()
+
+    suspend fun create(dto: PersonDto): PersonDto =
+        httpClient.post("/api/persons") {
+            contentType(ContentType.Application.Json)
+            setBody(dto)
+        }.body()
+
+    suspend fun update(id: Long, dto: PersonDto): PersonDto =
+        httpClient.put("/api/persons/$id") {
+            contentType(ContentType.Application.Json)
+            setBody(dto)
+        }.body()
+
+    suspend fun delete(id: Long) {
+        httpClient.delete("/api/persons/$id")
+    }
+}
+```
+
+## Compose Screen Patterns
+
+### List Screen
+
+```kotlin
+@Composable
+fun PersonListScreen(
+    onPersonClick: (Long) -> Unit,
+    onAddClick: () -> Unit
+) {
+    val apiClient = koinInject<PersonApiClient>()
+    var persons by remember { mutableStateOf<List<PersonDto>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        try {
+            persons = apiClient.getAll()
+        } catch (e: Exception) {
+            error = e.message
+        } finally {
+            isLoading = false
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Persons") })
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddClick) {
+                Icon(Icons.Default.Add, contentDescription = "Add Person")
+            }
+        }
+    ) { padding ->
+        when {
+            isLoading -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            error != null -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Error: $error", color = MaterialTheme.colorScheme.error)
+                }
+            }
+            else -> {
+                LazyColumn(contentPadding = padding) {
+                    items(persons, key = { it.id!! }) { person ->
+                        PersonListItem(
+                            person = person,
+                            onClick = { onPersonClick(person.id!!) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PersonListItem(person: PersonDto, onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text("${person.firstName} ${person.lastName}") },
+        supportingContent = { Text(person.email) },
+        modifier = Modifier.clickable(onClick = onClick)
+    )
+}
+```
+
+### Detail/Edit Screen
+
+```kotlin
+@Composable
+fun PersonDetailScreen(
+    personId: Long?,
+    onNavigateBack: () -> Unit
+) {
+    val apiClient = koinInject<PersonApiClient>()
+    var firstName by remember { mutableStateOf("") }
+    var lastName by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var isSaving by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(personId) {
+        if (personId != null) {
+            val person = apiClient.getById(personId)
+            firstName = person.firstName
+            lastName = person.lastName
+            email = person.email
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (personId == null) "New Person" else "Edit Person") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = firstName,
+                onValueChange = { firstName = it },
+                label = { Text("First Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = lastName,
+                onValueChange = { lastName = it },
+                label = { Text("Last Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("Email") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = {
+                    scope.launch {
+                        isSaving = true
+                        try {
+                            val dto = PersonDto(
+                                id = personId,
+                                firstName = firstName,
+                                lastName = lastName,
+                                email = email
+                            )
+                            if (personId == null) {
+                                apiClient.create(dto)
+                            } else {
+                                apiClient.update(personId, dto)
+                            }
+                            onNavigateBack()
+                        } catch (e: Exception) {
+                            snackbarHostState.showSnackbar("Error: ${e.message}")
+                        } finally {
+                            isSaving = false
+                        }
+                    }
+                },
+                enabled = !isSaving,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (isSaving) "Saving..." else "Save")
+            }
+        }
+    }
+}
+```
+
+## Koin Module Pattern
+
+```kotlin
+val uiModule = module {
+    single {
+        HttpClient {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                })
+            }
+            defaultRequest {
+                url("http://localhost:8080")
+            }
+        }
+    }
+    single { PersonApiClient(get()) }
+}
+```
+
+## Build Tool Discovery
+
+- Check for `.mise.toml` in the project root. If present, use `mise run build` (or the equivalent task name).
+- If no mise configuration exists, fall back to `./gradlew build`.
+
+## Workflow
+
+1. Read the use case specification from `docs/use_cases/`
+2. Verify the shared DTOs exist in `commonMain` (if not, run `/implement` first)
+3. Check existing UI code for patterns, navigation setup, and conventions
+4. Implement the Ktor Client API class
+5. Implement the Compose screens following Material 3 patterns
+6. Register the Koin module
+7. Wire screens into the navigation graph
+8. Verify the implementation compiles across all targets
+
+## Resources
+
+- Use the KotlinDocs MCP server for Compose Multiplatform and Ktor Client API reference

--- a/aiup-compose-ktor-exposed/skills/implement/SKILL.md
+++ b/aiup-compose-ktor-exposed/skills/implement/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: implement
+description: >
+  Implements use cases by creating shared @Serializable DTOs in commonMain,
+  Exposed DSL table definitions and queries for the data access layer, and
+  Ktor route handlers for the REST API. Use when the user asks to "implement
+  a use case", "build the backend", "create the API", "write the data access
+  layer", or mentions Ktor implementation, Exposed queries, REST endpoints,
+  or backend development.
+---
+
+# Implement Use Case (Backend)
+
+## Instructions
+
+Implement the backend for use case $ARGUMENTS using:
+- Shared `@Serializable` data classes in `commonMain` for DTOs
+- Exposed DSL for data access (PostgreSQL)
+- Ktor route handlers for REST endpoints
+- Koin for dependency injection
+
+Don't create tests -- there are the `ktor-test` and `compose-test` skills for that.
+Don't create UI screens -- there is the `implement-ui` skill for that.
+
+## DO NOT
+
+- Create test classes (use dedicated testing skills instead)
+- Create Compose UI screens (use `implement-ui` instead)
+- Use Exposed DAO style (use DSL style only)
+- Use `runBlocking` inside route handlers (Ktor handlers are already suspending)
+- Put server-only code in `commonMain` (Exposed tables and Ktor routes go in the server module)
+- Forget `@Serializable` annotation on DTOs
+
+## Architecture Layers
+
+```
+commonMain/
+  └── model/           # @Serializable DTOs shared between client and server
+      └── PersonDto.kt
+
+server (jvmMain)/
+  ├── db/              # Exposed table definitions
+  │   └── PersonTable.kt
+  ├── repository/      # Data access using Exposed DSL
+  │   └── PersonRepository.kt
+  ├── route/           # Ktor route handlers
+  │   └── PersonRoutes.kt
+  └── di/              # Koin module definitions
+      └── PersonModule.kt
+```
+
+> **Note:** The actual package/directory structure must be discovered from the existing project.
+> The above is a reference pattern — always follow existing conventions.
+
+## Shared DTO Pattern
+
+```kotlin
+// In commonMain
+@Serializable
+data class PersonDto(
+    val id: Long? = null,
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val birthDate: LocalDate? = null
+)
+```
+
+## Exposed Table Definition
+
+```kotlin
+// In server module
+object Persons : LongIdTable("person") {
+    val firstName = varchar("first_name", 100)
+    val lastName = varchar("last_name", 100)
+    val email = varchar("email", 255).uniqueIndex()
+    val birthDate = date("birth_date").nullable()
+}
+```
+
+## Repository Pattern
+
+```kotlin
+// In server module
+class PersonRepository {
+    suspend fun findAll(): List<PersonDto> = newSuspendedTransaction {
+        Persons.selectAll().map { it.toPersonDto() }
+    }
+
+    suspend fun findById(id: Long): PersonDto? = newSuspendedTransaction {
+        Persons.selectAll().where { Persons.id eq id }
+            .map { it.toPersonDto() }
+            .singleOrNull()
+    }
+
+    suspend fun create(dto: PersonDto): Long = newSuspendedTransaction {
+        Persons.insertAndGetId {
+            it[firstName] = dto.firstName
+            it[lastName] = dto.lastName
+            it[email] = dto.email
+            it[birthDate] = dto.birthDate
+        }.value
+    }
+
+    suspend fun update(id: Long, dto: PersonDto): Boolean = newSuspendedTransaction {
+        Persons.update({ Persons.id eq id }) {
+            it[firstName] = dto.firstName
+            it[lastName] = dto.lastName
+            it[email] = dto.email
+            it[birthDate] = dto.birthDate
+        } > 0
+    }
+
+    suspend fun delete(id: Long): Boolean = newSuspendedTransaction {
+        Persons.deleteWhere { Persons.id eq id } > 0
+    }
+
+    private fun ResultRow.toPersonDto() = PersonDto(
+        id = this[Persons.id].value,
+        firstName = this[Persons.firstName],
+        lastName = this[Persons.lastName],
+        email = this[Persons.email],
+        birthDate = this[Persons.birthDate]
+    )
+}
+```
+
+## Ktor Route Pattern
+
+```kotlin
+// In server module
+fun Route.personRoutes() {
+    val repository by inject<PersonRepository>()
+
+    route("/api/persons") {
+        get {
+            call.respond(repository.findAll())
+        }
+        get("/{id}") {
+            val id = call.parameters["id"]?.toLongOrNull()
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "Invalid ID")
+            val person = repository.findById(id)
+                ?: return@get call.respond(HttpStatusCode.NotFound)
+            call.respond(person)
+        }
+        post {
+            val dto = call.receive<PersonDto>()
+            val id = repository.create(dto)
+            call.respond(HttpStatusCode.Created, dto.copy(id = id))
+        }
+        put("/{id}") {
+            val id = call.parameters["id"]?.toLongOrNull()
+                ?: return@put call.respond(HttpStatusCode.BadRequest, "Invalid ID")
+            val dto = call.receive<PersonDto>()
+            if (repository.update(id, dto)) {
+                call.respond(HttpStatusCode.OK, dto.copy(id = id))
+            } else {
+                call.respond(HttpStatusCode.NotFound)
+            }
+        }
+        delete("/{id}") {
+            val id = call.parameters["id"]?.toLongOrNull()
+                ?: return@delete call.respond(HttpStatusCode.BadRequest, "Invalid ID")
+            if (repository.delete(id)) {
+                call.respond(HttpStatusCode.NoContent)
+            } else {
+                call.respond(HttpStatusCode.NotFound)
+            }
+        }
+    }
+}
+```
+
+## Koin Module Pattern
+
+```kotlin
+// In server module
+val personModule = module {
+    single { PersonRepository() }
+}
+```
+
+## Build Tool Discovery
+
+- Check for `.mise.toml` in the project root. If present, use `mise run build` (or the equivalent task name).
+- If no mise configuration exists, fall back to `./gradlew build`.
+
+## Workflow
+
+1. Read the use case specification from `docs/use_cases/`
+2. Read the entity model from `docs/entity_model.md`
+3. Check existing code for patterns and conventions (inspect `settings.gradle.kts` for module names)
+4. Create `@Serializable` DTOs in `commonMain`
+5. Create Exposed table definitions in the server module (if not already present from migrations)
+6. Implement the repository using Exposed DSL
+7. Implement the Ktor route handlers
+8. Register the Koin module
+9. Wire routes into the Ktor application module
+10. Verify the implementation compiles successfully
+
+## Resources
+
+- Use the KotlinDocs MCP server for Exposed DSL and Ktor API reference

--- a/aiup-compose-ktor-exposed/skills/ktor-test/SKILL.md
+++ b/aiup-compose-ktor-exposed/skills/ktor-test/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: ktor-test
+description: >
+  Creates Ktor server-side API tests using the testApplication DSL covering
+  endpoint behavior, request validation, response status codes, JSON
+  serialization, and error handling. Use when the user asks to "write API
+  tests", "test the Ktor endpoints", "create backend tests", "unit test the
+  routes", or mentions Ktor testing, testApplication, API testing, endpoint
+  tests, or server-side testing.
+---
+
+# Ktor Test
+
+## Instructions
+
+Create Ktor API tests for use case $ARGUMENTS using:
+- Ktor `testApplication {}` DSL for in-process testing (no real HTTP server)
+- Koin test modules for dependency injection
+- kotlin.test for test annotations
+- Kotest assertions for expressive matchers
+- Flyway test migrations for test data
+
+## DO NOT
+
+- Start a real HTTP server (use `testApplication {}` which runs in-process)
+- Use Mockito or MockK for mocking repositories (use a real test database with Flyway)
+- Use `runBlocking` in tests (Ktor test client is already suspending)
+- Delete all data in cleanup (only remove data created during the test)
+- Hardcode port numbers (tests run in-process, no ports needed)
+- Forget to install `ContentNegotiation` in the test client
+
+## Test Data Strategy
+
+Create test data using Flyway migrations in `src/test/resources/db/migration`.
+
+| Approach         | Location                               | Purpose                  |
+|------------------|----------------------------------------|--------------------------|
+| Flyway migration | src/test/resources/db/migration/V*.sql | Populate test data       |
+| Manual cleanup   | @AfterTest function                    | Remove test-created data |
+
+## Template
+
+Use [templates/ExampleRouteTest.kt](templates/ExampleRouteTest.kt) as the test class structure.
+
+## Common Patterns
+
+### Basic Test Setup
+
+```kotlin
+class PersonRoutesTest {
+
+    @Test
+    fun `GET persons returns list`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+
+        val response = client.get("/api/persons") {
+            accept(ContentType.Application.Json)
+        }
+
+        response.status shouldBe HttpStatusCode.OK
+        val persons = response.body<List<PersonDto>>()
+        persons.shouldNotBeEmpty()
+    }
+}
+```
+
+### Test Client with JSON Support
+
+```kotlin
+fun ApplicationTestBuilder.jsonClient() = createClient {
+    install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
+        json(Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        })
+    }
+}
+```
+
+### GET Endpoint Tests
+
+```kotlin
+@Test
+fun `GET person by id returns person`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val response = client.get("/api/persons/1")
+
+    response.status shouldBe HttpStatusCode.OK
+    val person = response.body<PersonDto>()
+    person.firstName shouldBe "Eula"
+}
+
+@Test
+fun `GET person by invalid id returns 404`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val response = client.get("/api/persons/99999")
+
+    response.status shouldBe HttpStatusCode.NotFound
+}
+```
+
+### POST Endpoint Tests
+
+```kotlin
+@Test
+fun `POST creates new person`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val newPerson = PersonDto(
+        firstName = "John",
+        lastName = "Doe",
+        email = "john.doe@example.com"
+    )
+
+    val response = client.post("/api/persons") {
+        contentType(ContentType.Application.Json)
+        setBody(newPerson)
+    }
+
+    response.status shouldBe HttpStatusCode.Created
+    val created = response.body<PersonDto>()
+    created.id.shouldNotBeNull()
+    created.firstName shouldBe "John"
+}
+```
+
+### PUT Endpoint Tests
+
+```kotlin
+@Test
+fun `PUT updates existing person`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val updated = PersonDto(
+        firstName = "Updated",
+        lastName = "Name",
+        email = "updated@example.com"
+    )
+
+    val response = client.put("/api/persons/1") {
+        contentType(ContentType.Application.Json)
+        setBody(updated)
+    }
+
+    response.status shouldBe HttpStatusCode.OK
+    val result = response.body<PersonDto>()
+    result.firstName shouldBe "Updated"
+}
+```
+
+### DELETE Endpoint Tests
+
+```kotlin
+@Test
+fun `DELETE removes person`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val response = client.delete("/api/persons/1")
+
+    response.status shouldBe HttpStatusCode.NoContent
+}
+
+@Test
+fun `DELETE non-existent person returns 404`() = testApplication {
+    application {
+        configureSerialization()
+        configureDI()
+        configureRouting()
+    }
+    val client = jsonClient()
+
+    val response = client.delete("/api/persons/99999")
+
+    response.status shouldBe HttpStatusCode.NotFound
+}
+```
+
+### Koin Test Module
+
+```kotlin
+fun Application.configureDI() {
+    install(Koin) {
+        modules(testModule)
+    }
+}
+
+val testModule = module {
+    single { PersonRepository() }
+}
+```
+
+## Assertions Reference
+
+Use Kotest assertions:
+
+| Assertion Type        | Example                                      |
+|-----------------------|----------------------------------------------|
+| Status code           | `response.status shouldBe HttpStatusCode.OK` |
+| Not null              | `person.id.shouldNotBeNull()`                |
+| String equality       | `person.firstName shouldBe "John"`           |
+| Collection not empty  | `persons.shouldNotBeEmpty()`                 |
+| Collection size       | `persons shouldHaveSize 5`                   |
+| Contains element      | `names shouldContain "John"`                 |
+
+## Build Tool Discovery
+
+- Check for `.mise.toml` in the project root. If present, use `mise run test` (or the equivalent task name).
+- If no mise configuration exists, fall back to `./gradlew test`.
+
+## Workflow
+
+1. Read the use case specification
+2. Use TodoWrite to create a task for each test scenario
+3. Create test class using the template
+4. For each test:
+    - Set up `testApplication` with required modules
+    - Create a JSON-enabled test client
+    - Send request to the endpoint
+    - Assert response status code and body
+    - Clean up test data if created during test
+5. Run tests to verify they pass
+6. If a test fails:
+    - Verify the application modules are correctly configured in the test
+    - Check that test data exists in the Flyway test migrations
+    - Ensure the test client has `ContentNegotiation` installed
+    - Verify serialization matches between request/response and DTOs
+7. Mark todos complete
+
+## Resources
+
+- Use the KotlinDocs MCP server for Ktor testing API reference

--- a/aiup-compose-ktor-exposed/skills/ktor-test/templates/ExampleRouteTest.kt
+++ b/aiup-compose-ktor-exposed/skills/ktor-test/templates/ExampleRouteTest.kt
@@ -1,0 +1,132 @@
+package com.example.app.routes
+
+import com.example.app.model.PersonDto
+import com.example.app.plugins.configureDI
+import com.example.app.plugins.configureRouting
+import com.example.app.plugins.configureSerialization
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.accept
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class ExampleRouteTest {
+
+    private fun ApplicationTestBuilder.jsonClient() = createClient {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                isLenient = true
+            })
+        }
+    }
+
+    @Test
+    fun `GET persons returns list`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+        val client = jsonClient()
+
+        val response = client.get("/api/persons") {
+            accept(ContentType.Application.Json)
+        }
+
+        response.status shouldBe HttpStatusCode.OK
+        val persons = response.body<List<PersonDto>>()
+        persons.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `GET person by id returns person`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+        val client = jsonClient()
+
+        val response = client.get("/api/persons/1")
+
+        response.status shouldBe HttpStatusCode.OK
+        val person = response.body<PersonDto>()
+        person.firstName shouldBe "Eula"
+    }
+
+    @Test
+    fun `GET person by invalid id returns 404`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+        val client = jsonClient()
+
+        val response = client.get("/api/persons/99999")
+
+        response.status shouldBe HttpStatusCode.NotFound
+    }
+
+    @Test
+    fun `POST creates new person and returns 201`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+        val client = jsonClient()
+
+        val newPerson = PersonDto(
+            firstName = "John",
+            lastName = "Doe",
+            email = "john.doe@example.com"
+        )
+
+        val response = client.post("/api/persons") {
+            contentType(ContentType.Application.Json)
+            setBody(newPerson)
+        }
+
+        response.status shouldBe HttpStatusCode.Created
+        val created = response.body<PersonDto>()
+        created.id.shouldNotBeNull()
+        created.firstName shouldBe "John"
+    }
+
+    @Test
+    fun `DELETE person returns 204`() = testApplication {
+        application {
+            configureSerialization()
+            configureDI()
+            configureRouting()
+        }
+        val client = jsonClient()
+
+        val response = client.delete("/api/persons/1")
+
+        response.status shouldBe HttpStatusCode.NoContent
+    }
+
+    @AfterTest
+    fun cleanup() {
+        // Remove test-created data here if needed
+    }
+}


### PR DESCRIPTION
Add new stack-specific plugin for Kotlin Multiplatform projects using Compose Multiplatform, Ktor, and Exposed with the following skills:

- flyway-migration: PostgreSQL DDL with Exposed table references
- implement: shared DTOs + Exposed DSL + Ktor routes + Koin DI
- implement-ui: Compose Multiplatform screens + Ktor Client wiring
- ktor-test: testApplication API tests with Kotest assertions
- compose-test: runComposeUiTest UI tests with semantics finders

Includes KotlinDocs MCP server config and template files for both test skills. Supports mise task discovery with Gradle fallback.