### PR TITLE
Improve aiup-core skills to raise eval scores; bump to 2.3.7

### DIFF
--- a/aiup-core/.claude-plugin/plugin.json
+++ b/aiup-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-core",
   "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-core/.tessl-plugin/plugin.json
+++ b/aiup-core/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup/aiup-core",
   "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-core/skills/requirements/SKILL.md
+++ b/aiup-core/skills/requirements/SKILL.md
@@ -88,6 +88,13 @@ Every requirement must pass these checks before finalizing:
   batch processing") and ask the user to resolve
 - **Missing stakeholder roles**: Default to generic roles (User, Admin, System) and note them for user review
 
+> **Format survives error recovery.** Ambiguity, conflict, and provisional
+> status never justify abandoning the user-story form. Every FR row — even one
+> you are flagging as conflicting or unconfirmed — must still read
+> "As a [role], I want [goal] so that [benefit]." Record the issue in a note or
+> in the Status column (e.g., `Conflict`, `Needs review`); never by dropping the
+> requirement to a flat statement like "Support real-time sync."
+
 ## Workflow
 
 1. Read the vision document or project brief
@@ -107,6 +114,8 @@ Every requirement must pass these checks before finalizing:
 7. Validate: run every requirement against the quality checks table above
     - No duplicate IDs across all tables
     - All Status columns filled
-    - All user stories follow "As a [role], I want [goal] so that [benefit]"
+    - **Hard gate:** every FR User Story matches "As a [role], I want [goal] so
+      that [benefit]" — scan each row; any row missing "As a", "I want", or "so
+      that" is rejected and rewritten before finalizing, no exceptions
     - All NFRs contain a measurable threshold
 8. Mark todos complete

--- a/aiup-core/skills/reverse-engineer/SKILL.md
+++ b/aiup-core/skills/reverse-engineer/SKILL.md
@@ -102,6 +102,22 @@ the entry points and group them by goal:
 - Pure infrastructure endpoints (`/health`, `/metrics`, static asset routes,
   framework-internal callbacks) are not use cases. Skip them.
 
+**Worked example — collapse CRUD endpoints into goals, not one-per-route:**
+
+| Endpoints found                                                            | Use cases (NOT one per endpoint)              |
+|----------------------------------------------------------------------------|-----------------------------------------------|
+| `GET /books`, `GET /books/{id}`, `POST /books`, `PUT /books/{id}`, `DELETE /books/{id}` | **UC-001 Manage Catalog** (one use case) |
+| `GET /cart`, `POST /cart/items`, `DELETE /cart/items/{id}`, `POST /checkout` | **UC-002 Place Order** (one use case)        |
+| `POST /login`, `POST /logout`, `GET /me`                                   | **UC-003 Authenticate** (one use case)        |
+
+Eight endpoints above → three use cases, not eight specs.
+
+**Self-check (do this before writing any spec):** count your endpoints and
+count your use cases. If the two numbers are close, you have *not* aggregated —
+you are mirroring the API surface. Re-group every endpoint under the actor goal
+it serves and merge until each use case is a complete goal an actor pursues
+end-to-end.
+
 Assign each use case an ID `UC-001`, `UC-002`, … in a stable order (group
 by actor, then by importance to the system's purpose). Pick a short
 descriptive name in title case.
@@ -200,8 +216,38 @@ For each entity, write:
 - A `### ENTITY_NAME` heading (UPPER_SNAKE_CASE).
 - A one-sentence description of what the entity represents (not what it
   contains — that's the table).
-- A 5-column attribute table: `Attribute | Description | Data Type |
-  Length/Precision | Validation Rules`.
+- An attribute table with **exactly these 5 columns, in this order**:
+  `Attribute | Description | Data Type | Length/Precision | Validation Rules`.
+
+Match this exact shape — a Mermaid block with relationships only, followed by
+one `###` section per entity with a filled 5-column table:
+
+```markdown
+# Entity Model
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    AUTHOR ||--o{ BOOK : "writes"
+    BOOK ||--o{ ORDER_ITEM : "appears in"
+```
+
+### BOOK
+
+A title available for sale in the catalog.
+
+| Attribute | Description           | Data Type | Length/Precision | Validation Rules                  |
+|-----------|-----------------------|-----------|------------------|-----------------------------------|
+| id        | Unique identifier     | Long      | 19               | Primary Key, Sequence             |
+| title     | Title of the book     | String    | 200              | Not Null                          |
+| isbn      | ISBN-13 code          | String    | 13               | Not Null, Unique                  |
+| price     | Sale price in CHF     | Decimal   | 10,2             | Not Null, Min: 0                  |
+| author_id | Author of the book    | Long      | 19               | Not Null, Foreign Key (AUTHOR.id) |
+```
+
+Never leave the Validation Rules column empty and never emit raw SQL types
+(`VARCHAR(200)`, `bigint`, `numeric`) — map them to the AIUP vocabulary below.
 
 Map types to the AIUP type vocabulary (`Long`, `String`, `Integer`,
 `Decimal`, `Boolean`, `Date`, `DateTime`) — don't leak `VARCHAR(255)` or
@@ -238,6 +284,12 @@ Before finishing, check the three documents agree:
   `BR-002`, …).
 - The mermaid diagram has a section for every entity it names, and every
   entity section appears in the diagram.
+- **Aggregation check:** your use-case count is meaningfully smaller than your
+  endpoint count. If it is not, you mirrored the API — go back and merge.
+- **Entity-model format check:** every attribute table has exactly 5 columns
+  in the required order; no raw SQL types (`VARCHAR`, `bigint`, `numeric`,
+  `int8`) appear anywhere; no Validation Rules cell is empty; no attributes
+  appear inside the Mermaid entity blocks.
 
 ### 8. Summarize for the user
 

--- a/aiup-core/skills/use-case-spec/references/use-case.md
+++ b/aiup-core/skills/use-case-spec/references/use-case.md
@@ -5,7 +5,7 @@
 **Use Case ID:** UC-XXX   
 **Use Case Name:** [Descriptive Name]   
 **Primary Actor:** [Role]   
-**Goal:** [What the actor wants to achieve]   
+**Goal:** [In one sentence: the observable outcome the actor achieves and why — not "use the system"]   
 **Status:** Draft | Reviewed | Approved | Implemented | Tested | Done | Obsolete
 
 ## Preconditions
@@ -22,11 +22,12 @@
 
 ### A1: [Alternative Flow Name]
 
-**Trigger:** [Condition that triggers this flow]
+**Trigger:** [Condition that triggers this flow] (step N)
 **Flow:**
 
 1. [Step that diverges from main flow]
-2. [Continuation or return to main flow]
+2. [Continuation]
+3. Use case continues at step N. *(or: Use case ends.)*
 
 ## Postconditions
 


### PR DESCRIPTION
- reverse-engineer: worked endpoint→use-case aggregation example + count self-check (Bookstore 'aggregated use cases' scored 0%); inline entity-model example with filled 5-column table + format gates ('5-column tables' 0%, 'ER diagram'/'AIUP data types' ~37%)
- requirements: enforce user-story format through conflict/ambiguity recovery and add a hard validation gate (CollabSpace 'user story format' 0%)
- use-case-spec template: Trigger references (step N), explicit flow endings, observable-outcome Goal (Place Order trigger/ending/goal criteria)