### PR TITLE
fix(docs): normalize Overview/Trigger fields to Markdown hard breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ requirements, non-functional requirements, and constraints.
 4. Extracts constraints (technical, regulatory, business) with stable IDs (CON-001, CON-002, …)
 5. Writes all three as separate tables in `docs/requirements.md` — never mixing requirement types in one table
 
-**Input:** `docs/vision.md`
-**Output:** `docs/requirements.md`
+**Input:** `docs/vision.md`  
+**Output:** `docs/requirements.md`  
 **Plugin:** `aiup-core`
 
 ---
@@ -446,8 +446,8 @@ requirements, non-functional requirements, and constraints.
    and validation rules (Primary Key, Sequence, NOT NULL, UNIQUE, foreign keys, check constraints)
 4. Writes the result to `docs/entity_model.md`
 
-**Input:** `docs/requirements.md`
-**Output:** `docs/entity_model.md`
+**Input:** `docs/requirements.md`  
+**Output:** `docs/entity_model.md`  
 **Plugin:** `aiup-core`
 
 ---
@@ -471,8 +471,8 @@ requirements catalog.
    boundary
 4. Uses standard PlantUML syntax only — no implementation details in use case names
 
-**Input:** `docs/requirements.md`
-**Output:** `docs/use_cases.puml`
+**Input:** `docs/requirements.md`  
+**Output:** `docs/use_cases.puml`  
 **Plugin:** `aiup-core`
 
 ---
@@ -498,8 +498,8 @@ requirements catalog.
 3. Keeps flow steps free of implementation details
 4. Refuses to bundle multiple use cases into a single document
 
-**Input:** Use case ID(s) as argument
-**Output:** `docs/use_cases/UC-XXX-*.md` (one file per use case)
+**Input:** Use case ID(s) as argument  
+**Output:** `docs/use_cases/UC-XXX-*.md` (one file per use case)  
 **Plugin:** `aiup-core`
 
 ---
@@ -528,8 +528,8 @@ the input that `/playwright-test TC-XXX` automates as a journey test.
 5. Keeps per-use-case detail out — field-level validations belong to the use case tests; the journey and its end
    state are the subject
 
-**Input:** Use case IDs as arguments
-**Output:** `docs/test_cases/TC-XXX-*.md` (one journey per file)
+**Input:** Use case IDs as arguments  
+**Output:** `docs/test_cases/TC-XXX-*.md` (one journey per file)  
 **Plugin:** `aiup-core`
 
 ---
@@ -557,8 +557,8 @@ codebase so legacy projects can join the AIUP workflow without rewriting documen
    referenced in a spec exists in the model)
 6. Reports gaps honestly — endpoints it couldn't classify, use cases where the success scenario was hard to recover
 
-**Input:** Existing source tree
-**Output:** `docs/use_cases.puml`, `docs/use_cases/UC-XXX-*.md`, `docs/entity_model.md`
+**Input:** Existing source tree  
+**Output:** `docs/use_cases.puml`, `docs/use_cases/UC-XXX-*.md`, `docs/entity_model.md`  
 **Plugin:** `aiup-core`
 
 ---
@@ -583,8 +583,8 @@ codebase so legacy projects can join the AIUP workflow without rewriting documen
 5. Writes scripts to `src/main/resources/db/migration`
 6. Will not drop existing tables without explicit confirmation
 
-**Input:** `docs/entity_model.md`
-**Output:** `src/main/resources/db/migration/V*.sql`
+**Input:** `docs/entity_model.md`  
+**Output:** `src/main/resources/db/migration/V*.sql`  
 **Plugin:** `aiup-vaadin-jooq`
 
 ---
@@ -608,8 +608,8 @@ codebase so legacy projects can join the AIUP workflow without rewriting documen
 5. Consults the Vaadin, jOOQ, and JavaDocs MCP servers for current API documentation
 6. Does **not** create test classes — use `/browserless-test` and `/playwright-test` for that
 
-**Input:** Use case ID as argument
-**Output:** Vaadin view + jOOQ data access classes
+**Input:** Use case ID as argument  
+**Output:** Vaadin view + jOOQ data access classes  
 **Plugin:** `aiup-vaadin-jooq`
 
 ---
@@ -637,8 +637,8 @@ and open source under Apache 2.0 since Vaadin 25.1.
 6. Preserves transaction boundaries — tests are not annotated `@Transactional`
 7. Reads component state through the component's Java API; reserves `test(...)` for actions
 
-**Input:** Use case ID as argument
-**Output:** Browserless test class under `src/test/java`
+**Input:** Use case ID as argument  
+**Output:** Browserless test class under `src/test/java`  
 **Plugin:** `aiup-vaadin-jooq`
 
 ---
@@ -668,8 +668,8 @@ tree without launching a browser.
 5. Preserves transaction boundaries — tests are not annotated `@Transactional`
 6. Uses the KaribuTesting MCP server for documentation and code generation
 
-**Input:** Use case ID as argument
-**Output:** Karibu test class under `src/test/java`
+**Input:** Use case ID as argument  
+**Output:** Karibu test class under `src/test/java`  
 **Plugin:** `aiup-vaadin-jooq`
 
 ---
@@ -709,8 +709,8 @@ type-safe, accessibility-first element wrappers. Covers two test types, dispatch
 8. Reuses existing test data from Flyway migrations; cleans up only test-created data in `@AfterEach`
 9. Looks up Drama Finder method signatures via the bundled API reference, falling back to the JavaDocs MCP server
 
-**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument
-**Output:** Playwright test under `src/test/java` — `UC*IT.java` for use case tests, `TC*IT.java` for journeys
+**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument  
+**Output:** Playwright test under `src/test/java` — `UC*IT.java` for use case tests, `TC*IT.java` for journeys  
 **Plugin:** `aiup-vaadin-jooq`
 
 ---
@@ -729,9 +729,9 @@ hexagonal layout).
 /flyway-migration
 ```
 
-**Input:** `docs/entity_model.md`
+**Input:** `docs/entity_model.md`  
 **Output:** `backend/src/main/resources/db/migration/V*.sql` (flat) or
-`<persistence-adapter-module>/src/main/resources/db/migration/V*.sql` (hexagonal)
+`<persistence-adapter-module>/src/main/resources/db/migration/V*.sql` (hexagonal)  
 **Plugin:** `aiup-angular-jpa`
 
 ---
@@ -760,8 +760,8 @@ multi-module (ports and adapters enforced at the Maven-module boundary) — and 
    `HttpClient` service with a colocated `*.model.ts`
 5. Does **not** create test classes — use `/spring-boot-test`, `/vitest-test`, and `/playwright-test` for that
 
-**Input:** Use case ID as argument
-**Output:** Backend classes per detected pattern, plus an Angular page/component
+**Input:** Use case ID as argument  
+**Output:** Backend classes per detected pattern, plus an Angular page/component  
 **Plugin:** `aiup-angular-jpa`
 
 ---
@@ -788,8 +788,8 @@ MockMvc — rather than assuming one.
    in the persistence-adapter module (the only one with the JPA classpath)
 4. Never mocks the repository/service layer with Mockito
 
-**Input:** Use case ID as argument
-**Output:** Spring Boot test class under the composition-root (hexagonal) or `backend/src/test/java` (flat)
+**Input:** Use case ID as argument  
+**Output:** Spring Boot test class under the composition-root (hexagonal) or `backend/src/test/java` (flat)  
 **Plugin:** `aiup-angular-jpa`
 
 ---
@@ -813,8 +813,8 @@ MockMvc — rather than assuming one.
 3. Mocks HTTP calls via `provideHttpClientTesting()`/`HttpTestingController`, verified with `httpMock.verify()`
 4. Reads state via signal getters and asserts on rendered DOM via native Angular queries
 
-**Input:** Use case ID as argument
-**Output:** Vitest spec file colocated with the component (`frontend/src/**/*.spec.ts`)
+**Input:** Use case ID as argument  
+**Output:** Vitest spec file colocated with the component (`frontend/src/**/*.spec.ts`)  
 **Plugin:** `aiup-angular-jpa`
 
 ---
@@ -839,8 +839,8 @@ e2e tooling, the skill checks for a conflicting framework (Cypress, Protractor) 
 4. Writes black-box tests against the running Angular dev server (default: `http://localhost:4200`) and backend
 5. Uses Playwright's own locators exclusively — never CSS selectors, XPath, or `waitForTimeout()`
 
-**Input:** Use case ID as argument
-**Output:** Playwright test file under `frontend/tests/e2e/`
+**Input:** Use case ID as argument  
+**Output:** Playwright test file under `frontend/tests/e2e/`  
 **Plugin:** `aiup-angular-jpa`
 
 ---
@@ -868,8 +868,8 @@ e2e tooling, the skill checks for a conflicting framework (Cypress, Protractor) 
 5. Never drops production schema and never hardcodes connection strings — those live in `appsettings.json`
    or environment variables
 
-**Input:** `docs/entity_model.md`
-**Output:** Entity classes, `IEntityTypeConfiguration<T>` files, and a migration class under `Migrations/`
+**Input:** `docs/entity_model.md`  
+**Output:** Entity classes, `IEntityTypeConfiguration<T>` files, and a migration class under `Migrations/`  
 **Plugin:** `aiup-blazor-dotnet`
 
 ---
@@ -900,8 +900,8 @@ e2e tooling, the skill checks for a conflicting framework (Cypress, Protractor) 
 7. Runs `dotnet build` to verify compilation; does **not** create test files — use `/bunit-test`, `/dotnet-test`,
    and `/playwright-test`
 
-**Input:** Use case ID as argument
-**Output:** A vertical slice under `Features/UCXXX_<FeatureName>/` plus navigation wiring
+**Input:** Use case ID as argument  
+**Output:** A vertical slice under `Features/UCXXX_<FeatureName>/` plus navigation wiring  
 **Plugin:** `aiup-blazor-dotnet`
 
 ---
@@ -927,8 +927,8 @@ without a browser.
    instead of arbitrary delays
 5. Runs `dotnet test` to confirm the tests pass
 
-**Input:** Use case ID as argument
-**Output:** bUnit test class in the test project
+**Input:** Use case ID as argument  
+**Output:** bUnit test class in the test project  
 **Plugin:** `aiup-blazor-dotnet`
 
 ---
@@ -953,8 +953,8 @@ domain logic.
    assert — so EF Core change tracking cannot mask bugs
 4. Runs `dotnet test` to confirm the tests pass
 
-**Input:** Use case ID as argument
-**Output:** xUnit test class in the test project
+**Input:** Use case ID as argument  
+**Output:** xUnit test class in the test project  
 **Plugin:** `aiup-blazor-dotnet`
 
 ---
@@ -980,8 +980,8 @@ domain logic.
    Blazor interactive hydration to complete before interacting
 4. Runs `dotnet test` to execute the suite against the application
 
-**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument
-**Output:** Playwright test class in the `*.Tests.E2E` project
+**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument  
+**Output:** Playwright test class in the `*.Tests.E2E` project  
 **Plugin:** `aiup-blazor-dotnet`
 
 ---

--- a/aiup-angular-jpa/evals/scenario-0/inputs/docs/use-cases/UC-010-browse-product-catalog.md
+++ b/aiup-angular-jpa/evals/scenario-0/inputs/docs/use-cases/UC-010-browse-product-catalog.md
@@ -1,7 +1,7 @@
-**Use Case ID:** UC-010
-**Name:** Browse Product Catalog
-**Primary Actor:** Shopper
-**Goal:** View available products and narrow them down by category
+**Use Case ID:** UC-010  
+**Name:** Browse Product Catalog  
+**Primary Actor:** Shopper  
+**Goal:** View available products and narrow them down by category  
 **Status:** Approved
 
 ## Preconditions

--- a/aiup-angular-jpa/evals/scenario-1/inputs/docs/use-cases/UC-020-register-guest.md
+++ b/aiup-angular-jpa/evals/scenario-1/inputs/docs/use-cases/UC-020-register-guest.md
@@ -1,7 +1,7 @@
-**Use Case ID:** UC-020
-**Name:** Register Guest
-**Primary Actor:** Front Desk Agent
-**Goal:** Register a new guest so they can be assigned to a reservation
+**Use Case ID:** UC-020  
+**Name:** Register Guest  
+**Primary Actor:** Front Desk Agent  
+**Goal:** Register a new guest so they can be assigned to a reservation  
 **Status:** Approved
 
 ## Preconditions

--- a/aiup-angular-jpa/evals/scenario-2/inputs/docs/use-cases/UC-020-register-guest.md
+++ b/aiup-angular-jpa/evals/scenario-2/inputs/docs/use-cases/UC-020-register-guest.md
@@ -1,7 +1,7 @@
-**Use Case ID:** UC-020
-**Name:** Register Guest
-**Primary Actor:** Front Desk Agent
-**Goal:** Register a new guest so they can be assigned to a reservation
+**Use Case ID:** UC-020  
+**Name:** Register Guest  
+**Primary Actor:** Front Desk Agent  
+**Goal:** Register a new guest so they can be assigned to a reservation  
 **Status:** Approved
 
 ## Preconditions

--- a/aiup-blazor-dotnet/evals/scenario-0/inputs/docs/use-cases/UC-010-browse-product-catalog.md
+++ b/aiup-blazor-dotnet/evals/scenario-0/inputs/docs/use-cases/UC-010-browse-product-catalog.md
@@ -1,7 +1,7 @@
-**Use Case ID:** UC-010
-**Name:** Browse Product Catalog
-**Primary Actor:** Shopper
-**Goal:** View available products and narrow them down by category
+**Use Case ID:** UC-010  
+**Name:** Browse Product Catalog  
+**Primary Actor:** Shopper  
+**Goal:** View available products and narrow them down by category  
 **Status:** Approved
 
 ## Preconditions

--- a/aiup-core/evals/scenario-10/docs/use_cases/UC-005-register-student.md
+++ b/aiup-core/evals/scenario-10/docs/use_cases/UC-005-register-student.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-**Use Case ID:** UC-005   
-**Use Case Name:** Register Student   
-**Primary Actor:** Administrator   
-**Goal:** The administrator registers a new student so the student can enroll in courses.   
+**Use Case ID:** UC-005  
+**Use Case Name:** Register Student  
+**Primary Actor:** Administrator  
+**Goal:** The administrator registers a new student so the student can enroll in courses.  
 **Status:** Approved
 
 ## Preconditions
@@ -27,7 +27,7 @@
 
 ### A1: Required field missing
 
-**Trigger:** A required field is empty when the administrator clicks "Save" (step 5)
+**Trigger:** A required field is empty when the administrator clicks "Save" (step 5)  
 **Flow:**
 
 1. The system marks the empty fields with the error "must not be empty" and keeps the dialog open.
@@ -35,7 +35,7 @@
 
 ### A2: Duplicate email
 
-**Trigger:** The entered email already belongs to a student (step 5)
+**Trigger:** The entered email already belongs to a student (step 5)  
 **Flow:**
 
 1. The system shows the error "A student with this email already exists" on the Email field and keeps the dialog open.

--- a/aiup-core/evals/scenario-10/docs/use_cases/UC-006-enroll-in-course.md
+++ b/aiup-core/evals/scenario-10/docs/use_cases/UC-006-enroll-in-course.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-**Use Case ID:** UC-006   
-**Use Case Name:** Enroll in Course   
-**Primary Actor:** Administrator   
-**Goal:** The administrator enrolls a registered student in a course so the student can attend it.   
+**Use Case ID:** UC-006  
+**Use Case Name:** Enroll in Course  
+**Primary Actor:** Administrator  
+**Goal:** The administrator enrolls a registered student in a course so the student can attend it.  
 **Status:** Approved
 
 ## Preconditions
@@ -29,7 +29,7 @@
 
 ### A1: Course is full
 
-**Trigger:** The selected course has no free capacity (step 5)
+**Trigger:** The selected course has no free capacity (step 5)  
 **Flow:**
 
 1. The system shows the error "Course is full" and keeps the dialog open.
@@ -37,7 +37,7 @@
 
 ### A2: Student already enrolled
 
-**Trigger:** The student is already enrolled in the selected course (step 5)
+**Trigger:** The student is already enrolled in the selected course (step 5)  
 **Flow:**
 
 1. The system shows the error "Student is already enrolled in this course" and keeps the dialog open.

--- a/aiup-core/skills/test-case/references/example.md
+++ b/aiup-core/skills/test-case/references/example.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**ID:** TC-001   
-**Goal:** A clerk creates a new order and a warehouse operator ships it — verifying the order lifecycle from creation to shipment end-to-end.   
-**Priority:** Critical   
+**ID:** TC-001  
+**Goal:** A clerk creates a new order and a warehouse operator ships it — verifying the order lifecycle from creation to shipment end-to-end.  
+**Priority:** Critical  
 **Status:** Approved
 
 ## Roles

--- a/aiup-core/skills/test-case/references/test-case.md
+++ b/aiup-core/skills/test-case/references/test-case.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**ID:** TC-XXX   
-**Goal:** [In one sentence: who does what across the journey and which outcome is verified end-to-end]   
-**Priority:** Critical | High | Medium | Low   
+**ID:** TC-XXX  
+**Goal:** [In one sentence: who does what across the journey and which outcome is verified end-to-end]  
+**Priority:** Critical | High | Medium | Low  
 **Status:** Draft | Reviewed | Approved | Automated | Obsolete
 
 ## Roles

--- a/aiup-core/skills/use-case-spec/references/example.md
+++ b/aiup-core/skills/use-case-spec/references/example.md
@@ -12,10 +12,10 @@ at `BR-004` here), and never restart at `BR-001`.
 
 ## Overview
 
-**Use Case ID:** UC-001
-**Use Case Name:** Create Reservation
-**Primary Actor:** Front Desk Clerk
-**Goal:** Create a new room reservation for a guest
+**Use Case ID:** UC-001  
+**Use Case Name:** Create Reservation  
+**Primary Actor:** Front Desk Clerk  
+**Goal:** Create a new room reservation for a guest  
 **Status:** Approved
 
 ## Preconditions
@@ -39,7 +39,7 @@ at `BR-004` here), and never restart at `BR-001`.
 
 ### A1: Guest Already Exists
 
-**Trigger:** Guest email matches existing record (step 3)
+**Trigger:** Guest email matches existing record (step 3)  
 **Flow:**
 
 1. System displays existing guest information.
@@ -48,7 +48,7 @@ at `BR-004` here), and never restart at `BR-001`.
 
 ### A2: No Rooms Available
 
-**Trigger:** No rooms available for selected dates (step 5)
+**Trigger:** No rooms available for selected dates (step 5)  
 **Flow:**
 
 1. System displays "No availability" message.
@@ -57,7 +57,7 @@ at `BR-004` here), and never restart at `BR-001`.
 
 ### A3: Payment Required
 
-**Trigger:** Business rule requires deposit (step 8)
+**Trigger:** Business rule requires deposit (step 8)  
 **Flow:**
 
 1. System prompts for payment information.

--- a/aiup-core/skills/use-case-spec/references/use-case.md
+++ b/aiup-core/skills/use-case-spec/references/use-case.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-**Use Case ID:** UC-XXX   
-**Use Case Name:** [Descriptive Name]   
-**Primary Actor:** [Role]   
-**Goal:** [In one sentence: the observable outcome the actor achieves and why — not "use the system"]   
+**Use Case ID:** UC-XXX  
+**Use Case Name:** [Descriptive Name]  
+**Primary Actor:** [Role]  
+**Goal:** [In one sentence: the observable outcome the actor achieves and why — not "use the system"]  
 **Status:** Draft | Reviewed | Approved | Implemented | Tested | Done | Obsolete
 
 ## Preconditions
@@ -22,7 +22,7 @@
 
 ### A1: [Alternative Flow Name]
 
-**Trigger:** [Condition that triggers this flow] (step N)
+**Trigger:** [Condition that triggers this flow] (step N)  
 **Flow:**
 
 1. [Step that diverges from main flow]

--- a/aiup-vaadin-jooq/evals/scenario-10/inputs/docs/test_cases/TC-001-order-fulfillment.md
+++ b/aiup-vaadin-jooq/evals/scenario-10/inputs/docs/test_cases/TC-001-order-fulfillment.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**ID:** TC-001   
-**Goal:** A clerk creates a new order and a warehouse operator ships it — verifying the order lifecycle from creation to shipment end-to-end.   
-**Priority:** Critical   
+**ID:** TC-001  
+**Goal:** A clerk creates a new order and a warehouse operator ships it — verifying the order lifecycle from creation to shipment end-to-end.  
+**Priority:** Critical  
 **Status:** Approved
 
 ## Roles

--- a/aiup-vaadin-jooq/evals/scenario-11/inputs/docs/test_cases/TC-002-patient-intake.md
+++ b/aiup-vaadin-jooq/evals/scenario-11/inputs/docs/test_cases/TC-002-patient-intake.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**ID:** TC-002   
-**Goal:** A receptionist registers a new patient and books their first appointment — verifying the intake journey from registration to a confirmed appointment end-to-end.   
-**Priority:** Critical   
+**ID:** TC-002  
+**Goal:** A receptionist registers a new patient and books their first appointment — verifying the intake journey from registration to a confirmed appointment end-to-end.  
+**Priority:** Critical  
 **Status:** Approved
 
 ## Roles

--- a/aiup-vaadin-jooq/evals/scenario-7/inputs/docs/use-cases/UC-040-borrow-book.md
+++ b/aiup-vaadin-jooq/evals/scenario-7/inputs/docs/use-cases/UC-040-borrow-book.md
@@ -1,7 +1,7 @@
 # UC-040: Borrow Book
 
-**Use Case ID:** UC-040
-**Use Case Name:** Borrow Book
+**Use Case ID:** UC-040  
+**Use Case Name:** Borrow Book  
 **Actor:** Library Member
 
 ## Description


### PR DESCRIPTION
Overview and Trigger field lines used a mix of no trailing space, one trailing space, two and three trailing spaces, so Markdown didn't reliably render each field on its own line in HTML/Confluence exports. Standardize on two trailing spaces.