### PR TITLE
Add aiup-blazor-dotnet and aiup-nestjs-nextjs to the generation catalogue

### DIFF
--- a/.github/workflows/aiup-generate.yml
+++ b/.github/workflows/aiup-generate.yml
@@ -95,6 +95,16 @@ jobs:
             aiup-angular-jpa/spring-boot-test) ;;
             aiup-angular-jpa/vitest-test) ;;
             aiup-angular-jpa/playwright-test) ;;
+            aiup-blazor-dotnet/ef-migration) ;;
+            aiup-blazor-dotnet/implement) ;;
+            aiup-blazor-dotnet/dotnet-test) ;;
+            aiup-blazor-dotnet/bunit-test) ;;
+            aiup-blazor-dotnet/playwright-test) ;;
+            aiup-nestjs-nextjs/drizzle-migration) ;;
+            aiup-nestjs-nextjs/implement) ;;
+            aiup-nestjs-nextjs/nest-test) ;;
+            aiup-nestjs-nextjs/react-test) ;;
+            aiup-nestjs-nextjs/playwright-test) ;;
             *)
               echo "::error::'$SKILL' of '$PLUGIN' is not in the catalogue of this marketplace"
               exit 1 ;;
@@ -122,7 +132,7 @@ jobs:
           # Only the skills that turn a specification into code or tests care how the
           # specification moved; the document skills rewrite their artifact as a whole.
           case "$SKILL" in
-            implement | implement-hilla | browserless-test | spring-boot-test | vitest-test | playwright-test) ;;
+            implement | implement-hilla | browserless-test | spring-boot-test | vitest-test | dotnet-test | bunit-test | nest-test | react-test | playwright-test) ;;
             *) exit 0 ;;
           esac
           # The subject of these skills is the path of the specification. A subject that
@@ -185,6 +195,8 @@ jobs:
             aiup-core@ai-unified-process-marketplace
             aiup-vaadin-jooq@ai-unified-process-marketplace
             aiup-angular-jpa@ai-unified-process-marketplace
+            aiup-blazor-dotnet@ai-unified-process-marketplace
+            aiup-nestjs-nextjs@ai-unified-process-marketplace
           # The diff of the specification follows the slash command; an empty hint
           # leaves the prompt as the bare command. Everything after the command name
           # reaches the skill as its arguments, and the skills expect the diff there.
@@ -227,7 +239,7 @@ jobs:
           case "$SKILL" in
             implement | implement-hilla)
               target=3; english=Implemented; german=Implementiert ;;
-            browserless-test | spring-boot-test | vitest-test)
+            browserless-test | spring-boot-test | vitest-test | dotnet-test | bunit-test | nest-test | react-test)
               target=4; english=Tested; german=Getestet ;;
             *)
               exit 0 ;;

--- a/pipelines/aiup-generate.sh
+++ b/pipelines/aiup-generate.sh
@@ -110,6 +110,8 @@ claude plugin marketplace add https://github.com/AI-Unified-Process/marketplace.
 claude plugin install aiup-core@ai-unified-process-marketplace
 claude plugin install aiup-vaadin-jooq@ai-unified-process-marketplace
 claude plugin install aiup-angular-jpa@ai-unified-process-marketplace
+claude plugin install aiup-blazor-dotnet@ai-unified-process-marketplace
+claude plugin install aiup-nestjs-nextjs@ai-unified-process-marketplace
 
 # The diff of the specification follows the slash command; an empty hint leaves the
 # prompt as the bare command. Everything after the command name reaches the skill as

--- a/pipelines/aiup-generate.sh
+++ b/pipelines/aiup-generate.sh
@@ -48,6 +48,16 @@ case "$PLUGIN/$SKILL" in
   aiup-angular-jpa/spring-boot-test) ;;
   aiup-angular-jpa/vitest-test) ;;
   aiup-angular-jpa/playwright-test) ;;
+  aiup-blazor-dotnet/ef-migration) ;;
+  aiup-blazor-dotnet/implement) ;;
+  aiup-blazor-dotnet/dotnet-test) ;;
+  aiup-blazor-dotnet/bunit-test) ;;
+  aiup-blazor-dotnet/playwright-test) ;;
+  aiup-nestjs-nextjs/drizzle-migration) ;;
+  aiup-nestjs-nextjs/implement) ;;
+  aiup-nestjs-nextjs/nest-test) ;;
+  aiup-nestjs-nextjs/react-test) ;;
+  aiup-nestjs-nextjs/playwright-test) ;;
   *)
     echo "ERROR: '$SKILL' of '$PLUGIN' is not in the catalogue of this marketplace" >&2
     exit 1 ;;
@@ -62,7 +72,7 @@ esac
 # specification it already fulfils.
 hint=""
 case "$SKILL" in
-  implement | implement-hilla | browserless-test | spring-boot-test | vitest-test | playwright-test)
+  implement | implement-hilla | browserless-test | spring-boot-test | vitest-test | dotnet-test | bunit-test | nest-test | react-test | playwright-test)
     # Only the skills that turn a specification into code or tests care how the
     # specification moved; the document skills rewrite their artifact as a whole.
     # The subject of these skills is the path of the specification. A subject that
@@ -135,7 +145,7 @@ advance_status() {
   case "$SKILL" in
     implement | implement-hilla)
       target=3; english=Implemented; german=Implementiert ;;
-    browserless-test | spring-boot-test | vitest-test)
+    browserless-test | spring-boot-test | vitest-test | dotnet-test | bunit-test | nest-test | react-test)
       target=4; english=Tested; german=Getestet ;;
     *)
       return 0 ;;


### PR DESCRIPTION
The reusable workflow (`aiup-generate.yml`) and the Bitbucket pipeline script (`pipelines/aiup-generate.sh`) rejected every run of the two new stack plugins because their catalogues still listed only `aiup-vaadin-jooq` and `aiup-angular-jpa`.

- The skills of `aiup-blazor-dotnet` (ef-migration, implement, dotnet-test, bunit-test, playwright-test) and `aiup-nestjs-nextjs` (drizzle-migration, implement, nest-test, react-test, playwright-test) join both catalogues.
- Both plugins join the install list of the workflow.
- The new test skills take part in the spec-diff hint and advance the specification status to Tested, like their peers.

Counterpart of the AIUP Studio change that adds both stacks (and the Vaadin Hilla variant) to the repository configuration.

https://claude.ai/code/session_018JY8EyG3g7QxKRQVgeuTap