### PR TITLE
docs: restructure marketplace documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,27 +9,27 @@
     {
       "name": "aiup-core",
       "source": "./aiup-core",
-      "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)"
+      "description": "AI Unified Process core - stack-agnostic requirements, entity model, and use cases"
     },
     {
       "name": "aiup-vaadin-jooq",
       "source": "./aiup-vaadin-jooq",
-      "description": "AI Unified Process plugin for the Vaadin/jOOQ stack"
+      "description": "AI Unified Process for the Vaadin/jOOQ stack - migrations, implementation, tests"
     },
     {
       "name": "aiup-angular-jpa",
       "source": "./aiup-angular-jpa",
-      "description": "AI Unified Process plugin for the Angular/JPA stack"
+      "description": "AI Unified Process for the Angular/JPA stack - migrations, implementation, tests"
     },
     {
       "name": "aiup-blazor-dotnet",
       "source": "./aiup-blazor-dotnet",
-      "description": "AI Unified Process plugin for the C# / Blazor .NET 10 stack"
+      "description": "AI Unified Process for the C# / Blazor .NET 10 stack - migrations, implementation, tests"
     },
     {
       "name": "aiup-nestjs-nextjs",
       "source": "./aiup-nestjs-nextjs",
-      "description": "AI Unified Process plugin for the NestJS/Drizzle + Next.js stack"
+      "description": "AI Unified Process for the NestJS/Drizzle + Next.js stack - migrations, implementation, tests"
     }
   ]
 }

--- a/.github/workflows/publish-tessl.yml
+++ b/.github/workflows/publish-tessl.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
+      - name: Rewrite marketplace-relative README links for the published package
+        run: |
+          bash scripts/rewrite-plugin-readme-links.sh \
+            "${{ matrix.plugin }}" \
+            "https://github.com/${{ github.repository }}" \
+            "${{ github.sha }}"
+
       - name: Publish ${{ matrix.plugin }} if its version is new
         run: |
           set -euo pipefail

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -17,6 +17,60 @@ jobs:
       - name: Check public documentation links
         run: bash scripts/validate-doc-links.sh
 
+      - name: Check standalone plugin README link rewriting
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          repository_url="https://github.com/${{ github.repository }}"
+          registry_url="https://tessl.io/registry/ai-unified-process"
+          git_ref=$(git rev-parse HEAD)
+          registry_links=0
+
+          for plugin_path in aiup-*/; do
+            plugin=${plugin_path%/}
+            cp -R "$plugin" "$tmp/$plugin"
+            bash scripts/rewrite-plugin-readme-links.sh "$tmp/$plugin" "$repository_url" "$git_ref"
+
+            # Scope the legacy-domain guard to the transformed README files that
+            # are actually published. Documentation may mention it as a warning.
+            if grep -q 'registry\.tessl\.io' "$tmp/$plugin/README.md"; then
+              echo "ERROR: legacy Tessl registry domain in transformed README: $plugin" >&2
+              exit 1
+            fi
+
+            while IFS= read -r url; do
+              package=${url#"$registry_url/"}
+              if [ "$package" = "$url" ] || [ ! -d "$package" ]; then
+                echo "ERROR: registry URL has no sibling plugin directory: $url" >&2
+                exit 1
+              fi
+              registry_links=$((registry_links + 1))
+            done < <(grep -o "${registry_url}/[^)]*" "$tmp/$plugin/README.md")
+
+            while IFS= read -r url; do
+              relative=${url#"$repository_url/blob/$git_ref/"}
+              if [ "$relative" = "$url" ]; then
+                relative=${url#"$repository_url/tree/$git_ref/"}
+                if [ "$relative" = "$url" ]; then
+                  echo "ERROR: unexpected rewritten URL: $url" >&2
+                  exit 1
+                fi
+              fi
+
+              relative=${relative%%#*}
+              if [ ! -e "$relative" ]; then
+                echo "ERROR: rewritten URL has no repository target: $url" >&2
+                exit 1
+              fi
+            done < <(grep -o "${repository_url}/[^)]*" "$tmp/$plugin/README.md")
+          done
+
+          if [ "$registry_links" -eq 0 ]; then
+            echo "ERROR: sibling-plugin registry rewrite was not exercised" >&2
+            exit 1
+          fi
+
       - name: Check use case spec validator and worked example
         run: |
           python3 aiup-core/skills/use-case-spec/scripts/validate_use_case.py --self-test

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Check Agent Plugins / Claude Code / Tessl manifest consistency
         run: bash scripts/validate-plugin-manifests.sh
 
+      - name: Check public documentation links
+        run: bash scripts/validate-doc-links.sh
+
       - name: Check use case spec validator and worked example
         run: |
           python3 aiup-core/skills/use-case-spec/scripts/validate_use_case.py --self-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,21 @@ marketplace/
 │       ├── bunit-test/
 │       ├── dotnet-test/
 │       └── playwright-test/
+├── aiup-nestjs-nextjs/           # NestJS + Drizzle / Next.js technology stack plugin
+│   ├── .claude-plugin/
+│   │   └── plugin.json           # Claude Code manifest
+│   ├── .mcp.json                 # Playwright
+│   ├── plugin.json               # Agent Plugins manifest (agent-plugins.org)
+│   ├── mcp.json                  # Agent Plugins MCP config
+│   └── skills/                   # All workflow steps as skills (slash commands)
+│       ├── drizzle-migration/
+│       ├── implement/
+│       ├── nest-test/
+│       ├── react-test/
+│       └── playwright-test/
+├── docs/                         # User guides, installation docs, and reusable templates
+├── pipelines/                    # Shared Bitbucket generation workflow implementation
+├── scripts/                      # Validation and publication helpers
 └── README.md
 ```
 
@@ -75,6 +90,7 @@ marketplace/
 - **vaadin-jooq** — Stack-specific: implementation and testing for the Vaadin + jOOQ stack. Requires core.
 - **angular-jpa** — Stack-specific: implementation and testing for the Angular + JPA stack. Requires core.
 - **blazor-dotnet** — Stack-specific: implementation and testing for C# / Blazor on .NET 10. Requires core.
+- **nestjs-nextjs** — Stack-specific: implementation and testing for NestJS / Drizzle and Next.js. Requires core.
 
 ### Marketplace Configuration
 
@@ -110,45 +126,58 @@ Skills follow the AI Unified Process phases: Inception, Elaboration, Constructio
 | Construction | `/use-case-spec`      | Write detailed use case specifications                               |
 | Construction | `/test-case`          | Write an end-to-end test case (TC-*) chaining several use cases      |
 | Any          | `/reverse-engineer`   | Recover use case diagram, use case specs, and entity model from code |
-| Construction | `/implement`          | Stack-agnostic dispatcher — detects the stack and delegates          |
-| Construction | `/test`               | Stack-agnostic dispatcher — server-side unit / integration tests     |
-| Construction | `/e2e`                | Stack-agnostic dispatcher — browser-based end-to-end tests           |
 
 ### Angular / JPA (stack-specific)
 
-| Phase        | Skill (slash command)    | Description                                                           |
-|--------------|--------------------------|-----------------------------------------------------------------------|
-| Construction | `/flyway-migration`      | Create Flyway migrations                                              |
-| Construction | `/implement`             | Implement use cases using Angular and Spring Boot JPA                 |
-| Construction | `/spring-boot-test`      | Create Spring Boot backend unit and integration tests                 |
-| Construction | `/vitest-test`           | Create Vitest component and unit tests for Angular                    |
-| Construction | `/playwright-test`       | Create Playwright E2E browser tests for Angular + Spring Boot         |
+| Phase        | Skill (slash command) | Description                                                   |
+|--------------|-----------------------|---------------------------------------------------------------|
+| Construction | `/flyway-migration`   | Create Flyway migrations                                      |
+| Construction | `/implement`          | Implement use cases using Angular and Spring Boot JPA         |
+| Construction | `/spring-boot-test`   | Create Spring Boot backend unit and integration tests         |
+| Construction | `/vitest-test`        | Create Vitest component and unit tests for Angular            |
+| Construction | `/playwright-test`    | Create Playwright E2E browser tests for Angular + Spring Boot |
 
 ### C# / Blazor .NET 10 (stack-specific)
 
-| Phase        | Skill (slash command)    | Description                                                           |
-|--------------|--------------------------|-----------------------------------------------------------------------|
-| Construction | `/ef-migration`          | Create native EF Core C# migrations                                   |
-| Construction | `/implement`             | Implement use cases using C# Vertical Slice Architecture              |
-| Construction | `/bunit-test`            | Create bUnit component tests for Blazor `.razor` pages                |
-| Construction | `/dotnet-test`           | Create backend integration tests for EF Core and domain handlers      |
-| Construction | `/playwright-test`       | Create native C# Playwright E2E tests (`Microsoft.Playwright.Xunit`)  |
+| Phase        | Skill (slash command) | Description                                                          |
+|--------------|-----------------------|----------------------------------------------------------------------|
+| Construction | `/ef-migration`       | Create native EF Core C# migrations                                  |
+| Construction | `/implement`          | Implement use cases using C# Vertical Slice Architecture             |
+| Construction | `/bunit-test`         | Create bUnit component tests for Blazor `.razor` pages               |
+| Construction | `/dotnet-test`        | Create backend integration tests for EF Core and domain handlers     |
+| Construction | `/playwright-test`    | Create native C# Playwright E2E tests (`Microsoft.Playwright.Xunit`) |
 
-### Vaadin/jOOQ (stack-specific — invoked by the core dispatchers)
+### Vaadin/jOOQ (stack-specific)
 
-| Phase        | Skill (slash command)    | Description                                               |
-|--------------|--------------------------|-----------------------------------------------------------|
-| Construction | `/flyway-migration`      | Create Flyway migrations                                  |
-| Construction | `/implement-vaadin-jooq` | Implement use cases using Vaadin Flow and jOOQ            |
-| Construction | `/implement-hilla`       | Implement use cases using Hilla (React) and jOOQ          |
-| Construction | `/browserless-test`      | Create Vaadin Browserless unit tests (recommended)        |
-| Construction | `/karibu-test`           | Create Karibu unit tests (legacy — superseded since 25.1) |
-| Construction | `/playwright-test`       | Create Playwright tests — use case (UC-*) or test case journey (TC-*) |
+| Phase        | Skill (slash command) | Description                                                           |
+|--------------|-----------------------|-----------------------------------------------------------------------|
+| Construction | `/flyway-migration`   | Create Flyway migrations                                              |
+| Construction | `/implement`          | Implement use cases using Vaadin Flow and jOOQ                        |
+| Construction | `/implement-hilla`    | Implement use cases using Hilla (React) and jOOQ                      |
+| Construction | `/browserless-test`   | Create Vaadin Browserless unit tests (recommended)                    |
+| Construction | `/karibu-test`        | Create Karibu unit tests (legacy — superseded since 25.1)             |
+| Construction | `/playwright-test`    | Create Playwright tests — use case (UC-*) or test case journey (TC-*) |
 
-The core `/implement`, `/test`, and `/e2e` skills inspect the project's build files (`pom.xml`, `build.gradle`,
-`package.json`, etc.) to choose which stack-specific skill to invoke. New stack plugins (e.g. a future
-`aiup-spring-react`) plug in by shipping their own `implement-<stack>` and test skills and adding a row to each
-dispatcher's routing table.
+### NestJS / Next.js (stack-specific)
+
+| Phase        | Skill (slash command) | Description                                                         |
+|--------------|-----------------------|---------------------------------------------------------------------|
+| Construction | `/drizzle-migration`  | Update the Drizzle schema and generate PostgreSQL migrations        |
+| Construction | `/implement`          | Implement NestJS API and Next.js App Router use cases               |
+| Construction | `/nest-test`          | Create Vitest unit tests and Supertest/Testcontainers backend tests |
+| Construction | `/react-test`         | Create React Testing Library component tests                        |
+| Construction | `/playwright-test`    | Create Playwright browser tests for UC-* or TC-* journeys           |
+
+Each stack plugin ships its own `/implement` and testing skills. Install exactly one stack plugin with `aiup-core` in
+a project so commands shared by several stack plugins do not collide.
+
+## Documentation
+
+- Start with `README.md` for the marketplace overview and `docs/getting-started.md` for the user workflow.
+- `docs/workflow.md` defines artifacts and traceability; `docs/installation/` contains host-specific setup guides.
+- Skill behavior is authoritative in each `skills/*/SKILL.md`.
+- Maintainers changing the shared generation workflows must read
+  [`docs/generate-workflow-versioning.md`](docs/generate-workflow-versioning.md) before moving the `v1` tag.
 
 ## Releasing to the Tessl Registry
 

--- a/README.md
+++ b/README.md
@@ -1,1370 +1,184 @@
 # AI Unified Process Marketplace
 
-A collection of Claude Code plugins that automate the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) — a
-structured workflow for taking a software project from raw vision to fully implemented, tested code, with requirements
-at the center at every step.
+AI Unified Process (AIUP) is a requirements-first workflow for taking software from a product vision to reviewed
+specifications, implementation, and traceable tests. This repository distributes the workflow as portable Agent
+Plugins and Agent Skills for Claude Code, OpenAI Codex, Cursor, GitHub Copilot, Gemini CLI, OpenCode, and other
+compatible coding agents.
 
-## What is the AI Unified Process?
+[Get started](docs/getting-started.md) · [Understand the workflow](docs/workflow.md) ·
+[Choose a plugin](#choose-your-plugins) · [Installation guides](#installation)
 
-AI Unified Process is a disciplined AI-assisted development methodology where every project starts with a written
-vision, proceeds
-through requirements, an entity model, and use case specifications, and only then enters implementation. Nothing gets
-built without a use case. Nothing reaches production without tests traceable to requirements.
+## Why AIUP?
 
-This prevents the common failure mode of AI-assisted development: jumping straight to code from a vague prompt,
-producing something that half-works and can't be maintained.
+AI-assisted development often jumps from a vague prompt directly to code. AIUP inserts durable, human-reviewable
+artifacts between intent and implementation:
 
-The methodology is based on the phases of
-the [Rational Unified Process](https://en.wikipedia.org/wiki/Rational_unified_process) — **Inception, Elaboration,
-Construction, Transition** — but adapted for AI-driven workflows.
+- requirements with stable identifiers;
+- an explicit domain entity model;
+- use cases that define user goals and behavior;
+- test journeys that trace back to those use cases;
+- stack-specific implementation and tests built from the reviewed specifications.
 
-## AI Unified Process Workflow
+The workflow is inspired by the phases of the
+[Rational Unified Process](https://en.wikipedia.org/wiki/Rational_unified_process), adapted for coding agents and
+plain-text artifacts that live with the source code.
 
-### Vaadin / jOOQ
+## Workflow
 
-```
-Inception          Elaboration                          Construction
-─────────────────  ──────────────────────────────────   ────────────────────────────────────────────────
-/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  /flyway-migration
-                                                                          ↘  /implement
-                                                                          ↘  /browserless-test
-                                                                          ↘  /playwright-test
-```
-
-### Angular / JPA
-
-For an Angular/JPA project, the inception and elaboration parts look the same, as they are part of the aiup-
-core plugin. The construction, however, is optimized for tech stack SpringBoot with JPA and Angular in frontend.
-It tests the frontend with Angular vitest unittests, the backend with spring-boot integrations tests and the whole
-app with playwright e2e tests. Further it takes existing backend architecture, a hexagonal multi-module Maven 
-reactor rather than a single flat module into consideration.
-
-```
-Inception          Elaboration                          Construction
-─────────────────  ──────────────────────────────────   ────────────────────────────────────────────────
-/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  /flyway-migration
-                                                                          ↘  /implement
-                                                                          ↘  /spring-boot-test
-                                                                          ↘  /vitest-test
-                                                                          ↘  /playwright-test
+```text
+Inception          Elaboration                            Construction
+─────────────     ───────────────────────────────────     ─────────────────────────────────
+/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  migration
+                                                                          ↘  implementation
+                                                                          ↘  tests
 ```
 
-### C# / Blazor .NET 10
+`aiup-core` owns the stack-independent path from vision to specifications. One stack plugin continues from those
+specifications into migrations, application code, and tests.
 
-For a C#/Blazor project the inception and elaboration parts are again the aiup-core ones. The construction phase
-targets .NET 10 with Blazor and Entity Framework Core, organizing each use case as a Vertical Slice
-(`Features/UCXXX_<FeatureName>/`). It tests Blazor components with bUnit, the backend handlers and EF Core code with
-xUnit, and the whole app with native C# Playwright tests.
+Each step reads the files produced by earlier steps. You can review or edit an artifact before continuing, and every
+later result remains traceable to the corresponding requirement or use case.
 
-```
-Inception          Elaboration                          Construction
-─────────────────  ──────────────────────────────────   ────────────────────────────────────────────────
-/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  /ef-migration
-                                                                          ↘  /implement
-                                                                          ↘  /bunit-test
-                                                                          ↘  /dotnet-test
-                                                                          ↘  /playwright-test
-```
+[Read about phases, artifacts, traceability, and change handling →](docs/workflow.md)
 
-### NestJS / Next.js
+## Choose your plugins
 
-For a NestJS/Next.js project the inception and elaboration parts are again the aiup-core ones. The construction
-phase targets a NestJS backend with Drizzle ORM over PostgreSQL and a Next.js App Router frontend — a split
-client/server architecture sharing only a JSON contract. It tests the backend with Vitest unit specs and Supertest
-end-to-end specs against a real PostgreSQL in Testcontainers, the frontend with Vitest and React Testing Library,
-and the whole app with Playwright. Being the first TypeScript-native stack here, it also encodes two failure modes
-the JVM and .NET plugins don't have: ESM/NodeNext `.js` import specifiers, and NestJS decorator metadata silently
-vanishing under a Vitest transformer that isn't SWC.
+Install `aiup-core` in every project. Add exactly one stack plugin when AIUP supports the project's implementation
+stack.
 
-```
-Inception          Elaboration                          Construction
-─────────────────  ──────────────────────────────────   ────────────────────────────────────────────────
-/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  /drizzle-migration
-                                                                          ↘  /implement
-                                                                          ↘  /nest-test
-                                                                          ↘  /react-test
-                                                                          ↘  /playwright-test
-```
+| Plugin                                      | Stack and responsibility                      | Construction skills                                                                                        |
+|---------------------------------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| [`aiup-core`](aiup-core/)                   | Stack-independent analysis and specifications | `/requirements`, `/entity-model`, `/use-case-diagram`, `/use-case-spec`, `/test-case`, `/reverse-engineer` |
+| [`aiup-vaadin-jooq`](aiup-vaadin-jooq/)     | Vaadin Flow or Hilla with jOOQ                | Flyway, implementation, Browserless or Karibu, Playwright                                                  |
+| [`aiup-angular-jpa`](aiup-angular-jpa/)     | Angular with Spring Boot and JPA              | Flyway, implementation, Spring Boot tests, Vitest, Playwright                                              |
+| [`aiup-blazor-dotnet`](aiup-blazor-dotnet/) | C# and Blazor on .NET 10 with EF Core         | EF migrations, Vertical Slices, bUnit, xUnit, Playwright                                                   |
+| [`aiup-nestjs-nextjs`](aiup-nestjs-nextjs/) | NestJS and Drizzle with Next.js App Router    | Drizzle migrations, implementation, Vitest, Supertest, React Testing Library, Playwright                   |
 
-Each skill picks up where the previous one left off using the files produced along the way (`docs/vision.md`,
-`docs/requirements.md`, `docs/entity_model.md`, `docs/use_cases.puml`, `docs/use_cases/UC-*.md`,
-`docs/test_cases/TC-*.md`). At any point you can
-inspect or manually edit these files before continuing.
+Use only `aiup-core` when working with another implementation stack. The methodology ends at a documented boundary,
+so the specifications can feed a custom implementation workflow.
 
-**Inheriting a legacy codebase?** Start with `/reverse-engineer` — it walks the existing code, configuration, and
-schema and produces the same `docs/use_cases.puml`, `docs/use_cases/UC-*.md`, and `docs/entity_model.md` artifacts the
-forward workflow would have produced, giving you a documented baseline to work from.
+## Quick start
 
-|                         | Inception       | Elaboration                            | Construction                                                                                       | Transition |
-|-------------------------|-----------------|----------------------------------------|----------------------------------------------------------------------------------------------------|------------|
-| **aiup-core**           | `/requirements` | `/entity-model`<br>`/use-case-diagram` | `/use-case-spec`<br>`/test-case`                                                                   |            |
-| **aiup-vaadin-jooq**    |                 |                                        | `/flyway-migration`<br>`/implement`<br>`/implement-hilla`<br>`/browserless-test`<br>`/playwright-test` |            |
-| **aiup-angular-jpa**    |                 |                                        | `/flyway-migration`<br>`/implement`<br>`/spring-boot-test`<br>`/vitest-test`<br>`/playwright-test` |            |
-| **aiup-blazor-dotnet**  |                 |                                        | `/ef-migration`<br>`/implement`<br>`/bunit-test`<br>`/dotnet-test`<br>`/playwright-test`          |            |
-| **aiup-nestjs-nextjs**  |                 |                                        | `/drizzle-migration`<br>`/implement`<br>`/nest-test`<br>`/react-test`<br>`/playwright-test`      |            |
+Before installing AIUP, create `docs/vision.md` in the target project. It should describe the mission, target users,
+goals, scope, and constraints. A copy-ready [vision template](docs/templates/vision.md) is available.
 
----
+### Claude Code
 
-## Prerequisites
-
-- [Claude Code](https://claude.ai/code) installed and running in your project
-- A `docs/vision.md` file at the root of your project describing the product vision, target users, and high-level
-  goals (the `/requirements` skill reads this file to derive your requirements catalog — the richer it is, the better
-  the results)
-- For the Vaadin/jOOQ plugin: a Maven or Gradle project with Vaadin and jOOQ already on the classpath
-- For the Angular/JPA plugin: a Maven or Gradle backend project with Spring Boot, Spring Data JPA, and Flyway
-  (flat single module or a hexagonal domain/business/postgres/api/app-style multi-module layout), plus a
-  separate Angular (standalone components) frontend project
-- For the C#/Blazor .NET 10 plugin: a .NET 10 solution (`.csproj`/`.sln`) using Blazor and Entity Framework Core
-- For the NestJS/Next.js plugin: a NestJS backend using Drizzle ORM over PostgreSQL (with `drizzle.config.ts`
-  present) and a Next.js App Router frontend — an npm workspace or two separate projects — plus Docker running
-  for the Testcontainers-backed e2e tests
-
-## Installation
-
-```
+```text
 /plugin marketplace add ai-unified-process/marketplace
 /plugin install aiup-core
-/plugin install aiup-vaadin-jooq        # for a Vaadin + jOOQ project
-/plugin install aiup-angular-jpa        # for an Angular + JPA project
-/plugin install aiup-blazor-dotnet      # for a C# + Blazor .NET 10 project
-/plugin install aiup-nestjs-nextjs      # for a NestJS + Next.js project
+/plugin install aiup-vaadin-jooq
 ```
 
-Install only `aiup-core` if you are using a different tech stack — the methodology skills are stack-agnostic.
-Install exactly one stack plugin alongside it, matching your project.
+Replace `aiup-vaadin-jooq` with the selected stack plugin.
 
-### Verify installation
-
-Start Claude Code in your project and run:
-
-```
-/requirements
-```
-
-If Claude begins reading `docs/vision.md` and proposing a requirements catalog, the skills are installed correctly.
-
----
-
-## Using AI Unified Process with other AI coding tools
-
-The AI Unified Process is a methodology, not a Claude-only product. Agent Skills (`SKILL.md`) is now an open standard,
-and the same skill folders in this marketplace work natively — with auto-triggering by description — in **OpenAI Codex
-CLI**, **Cursor**, **GitHub Copilot**, **Gemini CLI**, and **OpenCode**. Pair them with the
-[MCP](https://modelcontextprotocol.io) server configs and the whole workflow runs unchanged.
-
-### Agent Plugins standard
-
-Every plugin directory in this marketplace is also a conformant [**Agent Plugins**](https://agent-plugins.org)
-package — the open, vendor-neutral plugin standard (spec v1.0.0) governed by a steering committee with
-representatives from Amazon, Cursor, Microsoft, OpenAI, and Vercel. Alongside the Claude Code manifests, each
-plugin ships a root-level `plugin.json` (`$schema: https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`)
-and `mcp.json`, and the `skills/` layout already follows the [Agent Skills](https://agentskills.io) spec the
-standard builds on. Any client that implements Agent Plugins can load a plugin straight from a checkout of this
-repository:
+### Any supported agent through Tessl
 
 ```sh
-git clone https://github.com/AI-Unified-Process/marketplace.git
-# point your Agent Plugins-conformant client at e.g. marketplace/aiup-core/
-```
-
-The Agent Plugins manifests are kept in lockstep with the Claude Code and Tessl ones by a CI check
-([`scripts/validate-plugin-manifests.sh`](scripts/validate-plugin-manifests.sh)).
-
-### Install via Tessl (any agent)
-
-[Tessl](https://tessl.io) is an agent-agnostic package manager and registry for skills: it installs versioned skills and
-wires the MCP servers into the correct per-agent directory for whichever coding agent it detects. All plugins are
-published to the Tessl registry as `ai-unified-process/aiup-core`, `ai-unified-process/aiup-vaadin-jooq`, `ai-unified-process/aiup-angular-jpa`,
-`ai-unified-process/aiup-blazor-dotnet`, and `ai-unified-process/aiup-nestjs-nextjs`, so
-this is the simplest way to adopt
-the workflow outside Claude Code — no manual cloning or per-tool MCP translation.
-
-```sh
-# one-time: configure your agent(s) — creates a tessl.json manifest at the repo root
-tessl init --agent claude-code          # or: cursor, gemini, codex, copilot, copilot-vscode, agents
-                                        # (repeat --agent to set up several at once)
-
-# install the plugins from the registry (latest, or pin @version)
+tessl init --agent agents
 tessl install ai-unified-process/aiup-core
-tessl install ai-unified-process/aiup-vaadin-jooq     # for a Vaadin + jOOQ project
-tessl install ai-unified-process/aiup-angular-jpa     # for an Angular + JPA project
-tessl install ai-unified-process/aiup-blazor-dotnet   # for a C# + Blazor .NET 10 project
-tessl install ai-unified-process/aiup-nestjs-nextjs   # for a NestJS + Next.js project
+tessl install ai-unified-process/aiup-vaadin-jooq
 ```
 
-Installed plugins land in `.tessl/plugins/` and are tracked in `tessl.json`, so versions are pinned and reproducible
-across your team. New versions are published automatically on every change by
-[`.github/workflows/publish-tessl.yml`](.github/workflows/publish-tessl.yml), so `tessl install` always resolves the
-latest release.
+Tessl installs versioned skills and maps their MCP servers into the configured agent layout.
+Replace `agents` with a host-specific identifier such as `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or
+`copilot-vscode` when you do not want the vendor-neutral layout.
 
-**What transfers across agents:**
+### Create the first artifacts
 
-- **Skills and methodology** — fully portable; every supported agent auto-triggers them by their `description`.
-- **MCP servers** — Tessl wires them into any agent that supports MCP. Most `aiup-vaadin-jooq` servers are HTTP (fine on
-  the agents listed above); a stdio-only client needs an HTTP↔stdio bridge (see [Caveats](#caveats)).
-- **Slash-command routing** — the dispatcher behavior (`/implement` → stack-specific skill) is a Claude Code idiom.
-  Other agents read the same Markdown but may not honor `/`-routing identically — invoke skills by intent instead
-  (say "implement UC-001" rather than relying on the dispatcher).
+Run the core skills in the target project:
 
-### Portability at a glance
-
-| Component                                                  | Portable? | Notes                                                                                  |
-|------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------|
-| `tessl install ai-unified-process/…`                                     | Yes       | Works on Claude Code, Cursor, Gemini, Codex, and Copilot — installs skills + MCP        |
-| Agent Plugins package (`aiup-*/plugin.json` + `mcp.json`)  | Yes       | Each plugin dir conforms to [agent-plugins.org](https://agent-plugins.org) v1.0.0      |
-| MCP servers (`aiup-*/.mcp.json`)                           | Yes       | Standard MCP — reformat the config per host                                            |
-| `SKILL.md` skill folders (`aiup-*/skills/*/`)              | Yes       | Native support in Codex CLI, Cursor, Copilot, Gemini CLI, and OpenCode                 |
-| Auto-triggering by `description`                           | Yes       | All tools above match user intent against the YAML frontmatter `description`           |
-| Workflow methodology (vision → requirements → … → tests)   | Yes       | The whole point — tool-agnostic                                                        |
-| `/plugin marketplace add …` install                        | Partial   | Works in Claude Code and GitHub Copilot; elsewhere use Tessl or clone this repo        |
-
-### Manual adoption recipe (without Tessl)
-
-Prefer not to use Tessl? You can wire the skills in by hand:
-
-1. `git clone https://github.com/ai-unified-process/marketplace.git` next to your project (or add as a submodule).
-2. Make the skill folders visible to your tool — either copy `aiup-core/skills/*/` and `aiup-vaadin-jooq/skills/*/`
-   into your tool's skills directory, or symlink them
-   (e.g. `ln -s /path/to/marketplace/aiup-core/skills/requirements ~/.codex/skills/requirements`).
-3. Configure the MCP servers from `aiup-core/.mcp.json` and `aiup-vaadin-jooq/.mcp.json` in your tool's MCP config file.
-4. Trigger skills the same way you would in Claude Code — say "write requirements" or invoke `/requirements`. The tool
-   matches your prompt against each skill's `description` and loads the matching `SKILL.md`. File outputs
-   (`docs/requirements.md`, `docs/entity_model.md`, `docs/use_cases.puml`, `docs/use_cases/UC-*.md`) are identical
-   regardless of tool, so the chain composes even if you mix tools across steps.
-
-### OpenAI Codex CLI
-
-- **Skills**: drop folders into `~/.codex/skills/` (user-global, default `$CODEX_HOME/skills`) or repo-local
-  `.agents/skills/`. Codex matches user prompts against each skill's `description` automatically; toggle per skill
-  with `allow_implicit_invocation`.
-- **MCP**: `~/.codex/config.toml` under `[mcp_servers.<name>]` blocks. Translate `aiup-vaadin-jooq/.mcp.json` like
-  this:
-
-```toml
-[mcp_servers.Vaadin]
-url = "https://mcp.vaadin.com/docs"
-
-[mcp_servers.playwright]
-command = "npx"
-args = ["@playwright/mcp@latest"]
-```
-
-See the [Codex skills docs](https://developers.openai.com/codex/skills) and the
-[Codex config reference](https://developers.openai.com/codex/config-reference) for the latest details.
-
-### Cursor
-
-- **Skills**: drop folders into project-local `.cursor/skills/` (Cursor 2.4+). Cursor matches against each skill's
-  `description` automatically. Note: there is no global skills directory yet — copy or symlink the marketplace skills
-  into each project.
-- **MCP**: project-level `.cursor/mcp.json` or global `~/.cursor/mcp.json` — uses `mcpServers` with the same shape
-  as Claude's `.mcp.json` (`url` for HTTP servers, `command` / `args` for stdio). Drop in the contents of
-  `aiup-vaadin-jooq/.mcp.json` directly.
-
-### GitHub Copilot
-
-- **Plugin marketplace**: Copilot understands Claude Code's marketplace commands directly, so you can install the
-  plugins the same way as in Claude Code — no manual skill copying or MCP translation:
-
-  ```
-  /plugin marketplace add ai-unified-process/marketplace
-  /plugin install aiup-core
-  /plugin install aiup-vaadin-jooq        # or: aiup-angular-jpa, aiup-blazor-dotnet, aiup-nestjs-nextjs
-  ```
-
-  This pulls in the skills *and* the MCP server configs from each plugin's `.mcp.json`.
-- **Skills** (manual alternative): Copilot reads from `.github/skills/`, `.claude/skills/`, and `.agents/skills/` —
-  pick one. Available in Copilot for VS Code, Visual Studio 2026, and the cloud agent.
-- **MCP** (manual alternative): workspace-level `.vscode/mcp.json` (commit it for your team), or user-level via
-  *MCP: Open User Configuration*. Use `"type": "http"` for remote servers and `"command"` / `"args"` for stdio.
-
-```jsonc
-// .vscode/mcp.json
-{
-  "servers": {
-    "Vaadin": { "type": "http", "url": "https://mcp.vaadin.com/docs" },
-    "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] }
-  }
-}
-```
-
-### Gemini CLI
-
-- **Skills**: drop folders into `.gemini/skills/` (project) or `~/.gemini/skills/` (global). Gemini CLI matches
-  prompts against each skill's `description` automatically.
-- **MCP**: `~/.gemini/settings.json` `mcpServers` object — same shape as Claude's `.mcp.json`, so it is a near-direct
-  copy.
-
-### OpenCode
-
-- **Skills**: drop folders into project-local `.opencode/skills/` or global `~/.config/opencode/skills/`. OpenCode
-  also scans `.claude/skills/` and `.agents/skills/` (project and home directory), so skills already installed for
-  Claude Code — or via Tessl with `--agent claude-code` or `--agent agents` — are picked up without copying. Skills
-  are loaded on demand through OpenCode's built-in `skill` tool, matched against each skill's `description`; access
-  can be restricted per skill with `permission.skill` patterns in `opencode.json`.
-- **MCP**: `opencode.json` at the project root (or `~/.config/opencode/opencode.json` globally) under the `"mcp"`
-  key — use `"type": "remote"` with `url` for HTTP servers and `"type": "local"` with a `command` array for stdio.
-  Translate `aiup-vaadin-jooq/.mcp.json` like this:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "Vaadin": { "type": "remote", "url": "https://mcp.vaadin.com/docs" },
-    "playwright": { "type": "local", "command": ["npx", "@playwright/mcp@latest"] }
-  }
-}
-```
-
-See the [OpenCode skills docs](https://opencode.ai/docs/skills/) and the
-[OpenCode MCP docs](https://opencode.ai/docs/mcp-servers/) for the latest details.
-
-### Caveats
-
-- **Argument passing** (`/use-case-spec UC-001`) works everywhere but the syntax varies — Codex, Gemini CLI,
-  and Cursor accept positional arguments after the skill name; in Copilot, pass the ID inline in the chat message
-  after invoking the skill; in OpenCode, skills are not slash commands — state the ID in your prompt
-  ("specify use case UC-001") and the agent loads the matching skill itself.
-- **HTTP MCP servers**: most aiup-vaadin-jooq servers are HTTP. Every tool listed above supports HTTP MCP. If you use
-  a client that is stdio-only, you need an HTTP-to-stdio MCP bridge.
-- **Cursor has no global skills directory** — copy or symlink the marketplace skills into each project's
-  `.cursor/skills/`.
-- **Methodology stays the same**: the file artifacts (`docs/*.md`, `docs/use_cases/UC-*.md`, Flyway migrations) are
-  the contract between steps. As long as a step produces the right file, the next step works regardless of which
-  tool ran the previous one.
-
----
-
-## How to use?
-
-Here is a complete end-to-end example of building a hotel reservation system.
-
-### Step 1 — Generate the requirements catalog
-
-```
+```text
 /requirements
-```
-
-Claude reads `docs/vision.md`, identifies functional requirements (as user stories), non-functional requirements (
-measurable quality attributes), and constraints, then writes them into `docs/requirements.md` as three separate tables.
-Every requirement gets a stable ID (FR-001, NFR-001, CON-001) and a status. Review the catalog before continuing.
-
----
-
-### Step 2 — Design the entity model
-
-```
 /entity-model
-```
-
-Claude reads `docs/requirements.md`, identifies the domain entities and their relationships, then writes
-`docs/entity_model.md` with a Mermaid ER diagram and one attribute table per entity (data type, length/precision,
-validation rules). Approve the model before moving to use cases.
-
----
-
-### Step 3 — Draw the use case diagram
-
-```
 /use-case-diagram
-```
-
-Claude reads `docs/requirements.md`, identifies actors and use cases, then writes a PlantUML diagram at
-`docs/use_cases.puml`. Each use case gets a stable ID (UC-001, UC-002, …) that traces back to one or more functional
-requirements.
-
----
-
-### Step 4 — Specify the use cases
-
-```
 /use-case-spec UC-001
-/use-case-spec UC-001 UC-002 UC-003     # multiple at once
 ```
 
-Claude writes a detailed specification per use case into `docs/use_cases/` covering actors, preconditions, the main
-success scenario as numbered steps, alternative flows for error conditions, postconditions, and business rules. Each
-spec is a single document — Claude will not bundle multiple use cases together.
+Agents that do not expose skills as slash commands can invoke them by intent, for example: "Create the requirements
+catalog from `docs/vision.md`" or "Specify UC-001".
 
----
+[Follow the complete getting-started guide →](docs/getting-started.md)
 
-### Step 5 — Create the database migrations
+## Generated artifacts
 
-```
-/flyway-migration
-```
+The stack-independent workflow creates a shared documentation contract:
 
-Claude reads `docs/entity_model.md` and writes versioned Flyway migrations (`V001__create_*.sql`, `V002__…`) into
-`src/main/resources/db/migration`. Primary keys use sequences (no auto-increment), foreign keys and check constraints
-are derived from the entity model. Run `mvn flyway:migrate` to apply.
-
----
-
-### Step 6 — Implement the use case
-
-```
-/implement UC-001
+```text
+docs/
+├── vision.md                         # maintained by the team
+├── requirements.md                   # /requirements
+├── entity_model.md                   # /entity-model
+├── use_cases.puml                    # /use-case-diagram
+├── use_cases/
+│   └── UC-001-*.md                   # /use-case-spec
+└── test_cases/
+    └── TC-001-*.md                   # /test-case
 ```
 
-Claude reads the use case spec, the entity model, and existing code to learn your conventions, then implements the data
-access layer with jOOQ and the UI with Vaadin. It compiles after each layer and stops on errors. It does **not** write
-tests — those have dedicated skills.
+Stack plugins consume these files and place generated code and tests according to the conventions of the target
+project. Their READMEs document the supported layouts and exact prerequisites.
 
----
+## Existing applications
 
-### Step 7 — Write Browserless unit tests
+Start an undocumented application with:
 
-```
-/browserless-test UC-001
-```
-
-Claude generates server-side Vaadin tests using the official **Vaadin Browserless** framework
-(`com.vaadin:browserless-test-junit6`) — no browser required. Tests cover navigation, component interactions, form
-validation, grid operations, and notifications. Test data is seeded via Flyway migrations under
-`src/test/resources/db/migration`; transaction boundaries are preserved (no `@Transactional` on tests).
-
-> Browserless Testing is free and open source under Apache 2.0 since Vaadin 25.1. It is the official successor to UI
-> Unit Testing (formerly part of the commercial TestBench) and replaces the community Karibu Testing library as the
-> recommended server-side testing approach. The legacy `/karibu-test` skill is still installed for existing projects
-> but is **no longer recommended** for new code — use `/browserless-test`.
-
----
-
-### Step 8 — Write Playwright integration tests
-
-```
-/playwright-test UC-001     # use case test — integration tests for one view
-/playwright-test TC-001     # test case journey — one end-to-end flow across views
-```
-
-Claude generates browser-based tests against the running application (default: `http://localhost:8080`) using
-the Drama Finder library for type-safe, accessibility-first element wrappers. Tests are written black-box — they do not
-look at the implementation — and never use raw Playwright locators or `Thread.sleep()`.
-
-The skill dispatches on the argument: a `UC-*` ID produces integration tests for a single view derived from the use
-case specification, while a `TC-*` ID reads a test case document from `docs/test_cases/TC-*.md` (a user journey
-chaining several use cases, created with `/test-case`) and produces one journey test class walking the whole flow. Test classes are named
-after the artifact: `UC-001` → `UC001CreateReservationIT`, `TC-001` → `TC001CustomerOnboardingIT`.
-
----
-
-## Skills Reference
-
-### `/requirements` — Requirements Catalog *(plugin-agnostic)*
-
-**Purpose:** Turns a `docs/vision.md` document into a structured `docs/requirements.md` catalog with functional
-requirements, non-functional requirements, and constraints.
-
-**Usage:**
-
-```
-/requirements
-```
-
-**What it does:**
-
-1. Reads `docs/vision.md` to understand product mission, users, and goals
-2. Extracts functional requirements as user stories (`As a [role], I want [goal] so that [benefit]`) with stable IDs (
-   FR-001, FR-002, …), priority, and status
-3. Extracts non-functional requirements as measurable quality attributes with category (Performance, Security,
-   Availability, …), priority, and status
-4. Extracts constraints (technical, regulatory, business) with stable IDs (CON-001, CON-002, …)
-5. Writes all three as separate tables in `docs/requirements.md` — never mixing requirement types in one table
-
-**Input:** `docs/vision.md`  
-**Output:** `docs/requirements.md`  
-**Plugin:** `aiup-core`
-
----
-
-### `/entity-model` — Entity Model *(plugin-agnostic)*
-
-**Purpose:** Designs the domain entity model with a Mermaid ER diagram and per-entity attribute tables.
-
-**Usage:**
-
-```
-/entity-model
-```
-
-**What it does:**
-
-1. Reads `docs/requirements.md` to identify the domain entities implied by the user stories
-2. Draws a Mermaid `erDiagram` showing entities and their relationships (cardinality, role names) — without listing
-   attributes inside the diagram
-3. Produces one attribute table per entity with columns for attribute name, description, data type, length/precision,
-   and validation rules (Primary Key, Sequence, NOT NULL, UNIQUE, foreign keys, check constraints)
-4. Writes the result to `docs/entity_model.md`
-
-**Input:** `docs/requirements.md`  
-**Output:** `docs/entity_model.md`  
-**Plugin:** `aiup-core`
-
----
-
-### `/use-case-diagram` — Use Case Diagram *(plugin-agnostic)*
-
-**Purpose:** Generates a PlantUML use case diagram showing actors, use cases, and their relationships derived from the
-requirements catalog.
-
-**Usage:**
-
-```
-/use-case-diagram
-```
-
-**What it does:**
-
-1. Reads `docs/requirements.md` to identify actors and the use cases they participate in
-2. Assigns stable IDs (UC-001, UC-002, …), each tracing to at least one functional requirement
-3. Writes a `.puml` file at `docs/use_cases.puml` using `left to right direction` and a `rectangle "System Name"`
-   boundary
-4. Uses standard PlantUML syntax only — no implementation details in use case names
-
-**Input:** `docs/requirements.md`  
-**Output:** `docs/use_cases.puml`  
-**Plugin:** `aiup-core`
-
----
-
-### `/use-case-spec` — Use Case Specification *(plugin-agnostic)*
-
-**Purpose:** Writes detailed specifications for one or more use cases, each as a separate document under
-`docs/use_cases/`.
-
-**Usage:**
-
-```
-/use-case-spec UC-001
-/use-case-spec UC-001 UC-002 UC-003     # multiple use cases at once
-```
-
-**What it does:**
-
-1. Reads `docs/use_cases.puml` and `docs/requirements.md` to scope the use case
-2. Writes one document per use case under `docs/use_cases/` using a fixed template covering: Overview (ID, name, primary
-   actor, goal, status), Preconditions, Main Success Scenario (numbered steps), Alternative Flows (for error
-   conditions), Postconditions, and Business Rules
-3. Keeps flow steps free of implementation details
-4. Refuses to bundle multiple use cases into a single document
-
-**Input:** Use case ID(s) as argument  
-**Output:** `docs/use_cases/UC-XXX-*.md` (one file per use case)  
-**Plugin:** `aiup-core`
-
----
-
-### `/test-case` — End-to-End Test Case Document *(plugin-agnostic)*
-
-**Purpose:** Writes an end-to-end test case document (`TC-*.md`) that chains several use cases into one user journey —
-the input that `/playwright-test TC-XXX` automates as a journey test.
-
-**Usage:**
-
-```
-/test-case UC-001 UC-004     # journey chaining the listed use cases
-```
-
-**What it does:**
-
-1. Reads the specification of every listed use case from `docs/use_cases/` (and refuses to chain unspecified ones)
-2. Assigns the next free `TC-XXX` ID and names the file after the journey's goal
-   (e.g. `docs/test_cases/TC-001-customer-onboarding.md`)
-3. Writes the document with a fixed template: Overview (ID, Goal, Priority, Status), Roles, Preconditions (each
-   naming its seeded data source), a Flow table (`Step | Name | Description | Test Data | Use Case`), Validation,
-   and Postconditions (the data the journey leaves behind — the automated test's cleanup contract)
-4. Orders the Flow as the business journey, inserts verification steps between actions, links each action step to its
-   use case spec, and uses literal test data values so the document is executable
-5. Keeps per-use-case detail out — field-level validations belong to the use case tests; the journey and its end
-   state are the subject
-
-**Input:** Use case IDs as arguments  
-**Output:** `docs/test_cases/TC-XXX-*.md` (one journey per file)  
-**Plugin:** `aiup-core`
-
----
-
-### `/reverse-engineer` — Reverse Engineer Existing Project *(plugin-agnostic)*
-
-**Purpose:** Recovers AI Unified Process artifacts (use case diagram, per-use-case specifications, entity model) from an existing
-codebase so legacy projects can join the AI Unified Process workflow without rewriting documentation by hand.
-
-**Usage:**
-
-```
+```text
 /reverse-engineer
 ```
 
-**What it does:**
-
-1. Detects the stack and locates entry points (controllers, routes, view classes), the data layer (ORM models or
-   schema migrations), and authentication/authorization configuration
-2. Identifies actors from role/authority definitions, authentication boundaries, and external system integrations
-3. Groups entry points by user goal — not one use case per HTTP endpoint — and assigns stable IDs (`UC-001`, `UC-002`, …)
-4. Writes a PlantUML use case diagram, one specification document per use case, and an entity model with a Mermaid ER
-   diagram, all in the exact formats produced by `/use-case-diagram`, `/use-case-spec`, and `/entity-model`
-5. Cross-validates that the three documents agree (every actor has a spec, every UC ID has a file, every entity
-   referenced in a spec exists in the model)
-6. Reports gaps honestly — endpoints it couldn't classify, use cases where the success scenario was hard to recover
-
-**Input:** Existing source tree  
-**Output:** `docs/use_cases.puml`, `docs/use_cases/UC-XXX-*.md`, `docs/entity_model.md`  
-**Plugin:** `aiup-core`
-
----
-
-### `/flyway-migration` — Flyway Database Migrations *(in aiup-vaadin-jooq)*
-
-**Purpose:** Generates versioned Flyway migration scripts (`V*.sql`) that create the schema described in
-`docs/entity_model.md`.
-
-**Usage:**
-
-```
-/flyway-migration
-```
-
-**What it does:**
-
-1. Reads `docs/entity_model.md` and translates each entity into a `CREATE TABLE` statement
-2. Creates a `CREATE SEQUENCE` for every primary key (no auto-increment)
-3. Adds NOT NULL, UNIQUE, CHECK, and foreign key constraints from the entity model's validation rules
-4. Names files using the Flyway convention `V001__create_<table>_table.sql`, `V002__…`
-5. Writes scripts to `src/main/resources/db/migration`
-6. Will not drop existing tables without explicit confirmation
-
-**Input:** `docs/entity_model.md`  
-**Output:** `src/main/resources/db/migration/V*.sql`  
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/implement` — Use Case Implementation
-
-**Purpose:** Implements a use case end-to-end using Vaadin for the UI layer and jOOQ for the data access layer.
-
-**Usage:**
-
-```
-/implement UC-001
-```
-
-**What it does:**
-
-1. Reads the use case specification from `docs/use_cases/` and the entity model from `docs/entity_model.md`
-2. Reads existing code first to match conventions before creating new files
-3. Implements the data access layer using jOOQ — verifies it compiles before continuing
-4. Implements the Vaadin view, wires it to the data access layer, and verifies the full implementation compiles
-5. Consults the Vaadin, jOOQ, and JavaDocs MCP servers for current API documentation
-6. Does **not** create test classes — use `/browserless-test` and `/playwright-test` for that
-
-**Input:** Use case ID as argument  
-**Output:** Vaadin view + jOOQ data access classes  
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/implement-hilla` — Use Case Implementation (Hilla)
-
-**Purpose:** Implements a use case end-to-end using Hilla — React/TypeScript views with file-based routing — for the
-UI layer and jOOQ for the data access layer.
-
-**Usage:**
-
-```
-/implement-hilla UC-001
-```
-
-**What it does:**
-
-1. Reads the use case specification from `docs/use_cases/` and the entity model from `docs/entity_model.md`
-2. Reads existing code first to match conventions before creating new files
-3. Implements the data access layer using jOOQ — verifies it compiles before continuing
-4. Implements a `@BrowserCallable` service delegating to the data access layer, then the React view as a `.tsx` file
-   under `src/main/frontend/views/`, calling the generated type-safe TypeScript client
-5. Consults the Vaadin, jOOQ, and JavaDocs MCP servers for current API documentation
-6. Does **not** create test classes — use the dedicated testing skills for that
-
-**Input:** Use case ID as argument
-**Output:** Hilla React view + `@BrowserCallable` service + jOOQ data access classes
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/browserless-test` — Vaadin Browserless Server-Side Tests *(recommended, in aiup-vaadin-jooq)*
-
-**Purpose:** Creates server-side unit tests for Vaadin views using the official **Vaadin Browserless** framework
-(`com.vaadin:browserless-test-junit6`) — no browser, no WebDriver, no servlet container. Browserless Testing is free
-and open source under Apache 2.0 since Vaadin 25.1.
-
-**Usage:**
-
-```
-/browserless-test UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec to derive the test scenarios
-2. Generates a JUnit 5 test class extending `SpringBrowserlessTest` (annotated `@SpringBootTest`)
-3. Uses the `$()` / `$view()` component query API for lookups and the `test()` wrapper for interactions
-4. Seeds test data via Flyway migrations under `src/test/resources/db/migration` — never via Mockito, services, or
-   `DSLContext`
-5. Cleans up only test-created data in `@AfterEach` (does not wipe the schema)
-6. Preserves transaction boundaries — tests are not annotated `@Transactional`
-7. Reads component state through the component's Java API; reserves `test(...)` for actions
-
-**Input:** Use case ID as argument  
-**Output:** Browserless test class under `src/test/java`  
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/karibu-test` — Karibu Server-Side Tests *(legacy — no longer recommended, in aiup-vaadin-jooq)*
-
-> **Use `/browserless-test` instead for new projects.** Since Vaadin 25.1 the official Browserless Testing framework
-> is free and open source under Apache 2.0, making the community Karibu Testing library redundant. This skill is
-> retained for existing codebases that already use Karibu.
-
-**Purpose:** Creates Karibu unit tests for Vaadin views — server-side tests that exercise the full Vaadin component
-tree without launching a browser.
-
-**Usage:**
-
-```
-/karibu-test UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec to derive the test scenarios
-2. Generates a JUnit 5 test class using Karibu helpers (`LocatorJ`, `GridKt`, `NotificationsKt`, `ConfirmDialogKt`)
-3. Seeds test data via Flyway migrations under `src/test/resources/db/migration` — never via Mockito, services, or
-   `DSLContext`
-4. Cleans up only test-created data in `@AfterEach` (does not wipe the schema)
-5. Preserves transaction boundaries — tests are not annotated `@Transactional`
-6. Uses the KaribuTesting MCP server for documentation and code generation
-
-**Input:** Use case ID as argument  
-**Output:** Karibu test class under `src/test/java`  
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/playwright-test` — Playwright Tests *(in aiup-vaadin-jooq)*
-
-**Purpose:** Creates browser-based tests for Vaadin views using Playwright with the Drama Finder library for
-type-safe, accessibility-first element wrappers. Covers two test types, dispatched on the argument:
-
-| Input | Artifact | Test type |
-|-------|----------|-----------|
-| `UC-*` | Use case specification (`docs/use_cases/UC-*.md`) | **Use case test** — integration tests for one view, grouped in `@Nested` classes |
-| `TC-*` | Test case document (`docs/test_cases/TC-*.md`) | **Test case journey** — one end-to-end test walking the whole flow across views |
-
-**Usage:**
-
-```
-/playwright-test UC-001     # integration tests for one view
-/playwright-test TC-001     # end-to-end journey test across views
-```
-
-**What it does:**
-
-1. Decides the test type from the argument (`UC-*` vs `TC-*`), then reads the matching document to derive the tests
-2. Generates a test extending `AbstractBasePlaywrightIT` (handles browser lifecycle, page creation, and
-   Vaadin synchronization automatically)
-3. For a use case: covers the main success scenario, alternative flows, and validation rules in `@Nested` classes
-4. For a test case journey: implements the whole **Flow** as a single `@Test` method with one private step method per
-   flow row, navigating between views through the UI like a user would — one test class per test case
-5. Names the test class after the artifact: `UC<id><PascalCaseName>IT` for use cases
-   (e.g. `UC-001-create-reservation.md` → `UC001CreateReservationIT`) and `TC<id><PascalCaseName>IT` for test cases
-   (e.g. `TC-001-customer-onboarding.md` → `TC001CustomerOnboardingIT`)
-6. Writes black-box tests against the running application (default: `http://localhost:8080`) — does not consult the
-   implementation
-7. Uses Drama Finder element wrappers exclusively — never raw Playwright locators, XPath, `Thread.sleep()`, or
-   `page.waitForTimeout()`
-8. Reuses existing test data from Flyway migrations; cleans up only test-created data in `@AfterEach`
-9. Looks up Drama Finder method signatures via the bundled API reference, falling back to the JavaDocs MCP server
-
-**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument  
-**Output:** Playwright test under `src/test/java` — `UC*IT.java` for use case tests, `TC*IT.java` for journeys  
-**Plugin:** `aiup-vaadin-jooq`
-
----
-
-### `/flyway-migration` — Flyway Database Migrations *(in aiup-angular-jpa)*
-
-**Purpose:** Generates versioned Flyway migration scripts (`V*.sql`) that create the schema described in
-`docs/entity_model.md`, using `snake_case` column names so they match Hibernate's default JPA field mapping.
-Detects whether the backend is a flat single module or a hexagonal multi-module Maven reactor and places
-migrations in the correct location (the persistence-adapter module's `db/migration` directory for a
-hexagonal layout).
-
-**Usage:**
-
-```
-/flyway-migration
-```
-
-**Input:** `docs/entity_model.md`  
-**Output:** `backend/src/main/resources/db/migration/V*.sql` (flat) or
-`<persistence-adapter-module>/src/main/resources/db/migration/V*.sql` (hexagonal)  
-**Plugin:** `aiup-angular-jpa`
-
----
-
-### `/implement` — Use Case Implementation *(in aiup-angular-jpa)*
-
-**Purpose:** Implements a use case end-to-end across a Spring Boot backend — flat single-module or hexagonal
-multi-module (ports and adapters enforced at the Maven-module boundary) — and an Angular frontend.
-
-**Usage:**
-
-```
-/implement UC-001
-```
-
-**What it does:**
-
-1. Reads the use case specification from `docs/use_cases/` and the entity model from `docs/entity_model.md`
-2. Detects the backend's module layout before writing any backend code, and follows whichever asymmetric
-   hexagonal conventions the project already established (e.g. outbound-only ports, no inbound use-case
-   interface) rather than "fixing" them into textbook full hexagonal
-3. Implements the backend per the detected pattern — pure domain record, service, outbound port, DTO, JPA
-   adapter, and REST controller for hexagonal; entity/repository/service/controller for flat — verifying
-   compilation at each module boundary
-4. Implements the frontend: a standalone Angular component using `signal()` state and a hand-written
-   `HttpClient` service with a colocated `*.model.ts`
-5. Does **not** create test classes — use `/spring-boot-test`, `/vitest-test`, and `/playwright-test` for that
-
-**Input:** Use case ID as argument  
-**Output:** Backend classes per detected pattern, plus an Angular page/component  
-**Plugin:** `aiup-angular-jpa`
-
----
-
-### `/spring-boot-test` — Spring Boot Backend Tests *(Angular/JPA)*
-
-**Purpose:** Creates Spring Boot tests for REST controllers and Spring Data JPA repositories, detecting and
-following whichever integration-test convention a project already uses — RestAssured + Testcontainers, or
-MockMvc — rather than assuming one.
-
-**Usage:**
-
-```
-/spring-boot-test UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec to derive the test scenarios
-2. Detects the existing test convention; if neither exists yet, defaults to RestAssured + Testcontainers
-   (exercises the real HTTP wire format and a real Postgres container, matching the convention this plugin
-   was built from)
-3. For a hexagonal layout, places integration tests in the composition-root module and any `@DataJpaTest`
-   in the persistence-adapter module (the only one with the JPA classpath)
-4. Never mocks the repository/service layer with Mockito
-
-**Input:** Use case ID as argument  
-**Output:** Spring Boot test class under the composition-root (hexagonal) or `backend/src/test/java` (flat)  
-**Plugin:** `aiup-angular-jpa`
-
----
-
-### `/vitest-test` — Angular Component Tests *(in aiup-angular-jpa)*
-
-**Purpose:** Creates Vitest component tests for Angular views using Angular's own testing idioms — `TestBed`,
-`ComponentFixture`, and `HttpTestingController` — rather than porting React Testing Library patterns.
-
-**Usage:**
-
-```
-/vitest-test UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec to derive the test scenarios
-2. Generates a test file named `UC-XXX-<slug>.spec.ts`, colocated with the component/service, with a
-   top-level `describe` block named after the use case
-3. Mocks HTTP calls via `provideHttpClientTesting()`/`HttpTestingController`, verified with `httpMock.verify()`
-4. Reads state via signal getters and asserts on rendered DOM via native Angular queries
-
-**Input:** Use case ID as argument  
-**Output:** Vitest spec file colocated with the component (`frontend/src/**/*.spec.ts`)  
-**Plugin:** `aiup-angular-jpa`
-
----
-
-### `/playwright-test` — Playwright End-to-End Tests *(in aiup-angular-jpa)*
-
-**Purpose:** Creates browser-based end-to-end tests for Angular views using Playwright's native
-accessibility-first locators — no wrapper library needed. Since these projects typically have no existing
-e2e tooling, the skill checks for a conflicting framework (Cypress, Protractor) before scaffolding Playwright.
-
-**Usage:**
-
-```
-/playwright-test UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec to derive the test scenarios
-2. Checks for an existing e2e framework before assuming Playwright is unclaimed
-3. Generates a test file grouping scenarios in a `test.describe` block per use case, tagged `{ tag: "@UC-XXX" }`
-4. Writes black-box tests against the running Angular dev server (default: `http://localhost:4200`) and backend
-5. Uses Playwright's own locators exclusively — never CSS selectors, XPath, or `waitForTimeout()`
-
-**Input:** Use case ID as argument  
-**Output:** Playwright test file under `frontend/tests/e2e/`  
-**Plugin:** `aiup-angular-jpa`
-
----
-
-### `/ef-migration` — EF Core Database Migrations *(in aiup-blazor-dotnet)*
-
-**Purpose:** Generates native EF Core C# migrations and the entity classes/configurations behind them from
-`docs/entity_model.md`.
-
-**Usage:**
-
-```
-/ef-migration
-```
-
-**What it does:**
-
-1. Reads `docs/entity_model.md` and inspects the existing `DbContext` and entity classes in the solution
-2. Writes entity classes with file-scoped namespaces, `required` properties, and nullable-reference-safe
-   navigation properties
-3. Adds `IEntityTypeConfiguration<T>` Fluent API mappings (table/column names, `HasPrecision`, enum
-   `HasConversion<string>()`, foreign keys, unique indexes) and registers them in `OnModelCreating`
-4. Runs `dotnet ef migrations add UCXXX_Description` (with `--project` / `--startup-project` flags for
-   multi-project solutions) and verifies the generated migration class
-5. Never drops production schema and never hardcodes connection strings — those live in `appsettings.json`
-   or environment variables
-
-**Input:** `docs/entity_model.md`  
-**Output:** Entity classes, `IEntityTypeConfiguration<T>` files, and a migration class under `Migrations/`  
-**Plugin:** `aiup-blazor-dotnet`
-
----
-
-### `/implement` — Use Case Implementation *(in aiup-blazor-dotnet)*
-
-**Purpose:** Implements a use case as a Vertical Slice in a C# / Blazor .NET 10 application.
-
-**Usage:**
-
-```
-/implement UC-001
-```
-
-**What it does:**
-
-1. Reads the use case spec, `docs/requirements.md` (including UI/UX constraints, styling directives, and
-   accessibility NFRs), and `docs/entity_model.md`
-2. Creates a feature folder `Features/UCXXX_<FeatureName>/` holding the Blazor page (`.razor`), its code-behind
-   (`.razor.cs`), scoped CSS (`.razor.css`), the Command/Query, the Handler, and the Validator
-3. Uses modern C# (file-scoped namespaces, primary constructors, `required` properties, collection expressions)
-   and picks the right render mode (`InteractiveServer` / `InteractiveAuto`, or static SSR for read-heavy pages)
-4. Accesses data through `IDbContextFactory<AppDbContext>` or handler abstractions — never a raw scoped
-   `DbContext` in an interactive component — and flows `CancellationToken` through async calls
-5. Styles the UI properly: design tokens, typography, hover/loading/empty/error states, responsive layouts, ARIA tags
-6. Removes `dotnet new blazor` boilerplate (`Counter.razor`, `Weather.razor`) and registers the new route in
-   `NavMenu.razor`
-7. Runs `dotnet build` to verify compilation; does **not** create test files — use `/bunit-test`, `/dotnet-test`,
-   and `/playwright-test`
-
-**Input:** Use case ID as argument  
-**Output:** A vertical slice under `Features/UCXXX_<FeatureName>/` plus navigation wiring  
-**Plugin:** `aiup-blazor-dotnet`
-
----
-
-### `/bunit-test` — bUnit Component Tests *(in aiup-blazor-dotnet)*
-
-**Purpose:** Creates bUnit component tests for Blazor `.razor` pages — full component rendering and interaction
-without a browser.
-
-**Usage:**
-
-```
-/bunit-test UC-001
-```
-
-**What it does:**
-
-1. Locates the Blazor component under test in its feature folder
-2. Generates an xUnit test class based on `Bunit.TestContext`, registering mock services via the bUnit DI
-   container and setting up authorization (`AddTestAuthorization()`) and JSInterop where the component needs them
-3. Renders with `RenderComponent<T>()`, interacts through `cut.Find(...)`, and asserts on markup
-4. Handles async lifecycle work (`OnInitializedAsync`, data fetching) with `WaitForState` / `WaitForAssertion`
-   instead of arbitrary delays
-5. Runs `dotnet test` to confirm the tests pass
-
-**Input:** Use case ID as argument  
-**Output:** bUnit test class in the test project  
-**Plugin:** `aiup-blazor-dotnet`
-
----
-
-### `/dotnet-test` — Backend Unit & Integration Tests *(in aiup-blazor-dotnet)*
-
-**Purpose:** Creates xUnit tests for non-UI C# code — EF Core `DbContext` access, vertical slice handlers, and
-domain logic.
-
-**Usage:**
-
-```
-/dotnet-test UC-001
-```
-
-**What it does:**
-
-1. Locates the target handler, repository, or domain service
-2. Backs the test with SQLite in-memory (connection held open) or Testcontainers — deliberately **not**
-   `UseInMemoryDatabase`, which enforces neither relational constraints nor raw SQL behavior
-3. Follows the AAA pattern with a *fresh `DbContext` per phase* — one to seed, a second to act, a third to
-   assert — so EF Core change tracking cannot mask bugs
-4. Runs `dotnet test` to confirm the tests pass
-
-**Input:** Use case ID as argument  
-**Output:** xUnit test class in the test project  
-**Plugin:** `aiup-blazor-dotnet`
-
----
-
-### `/playwright-test` — Native C# Playwright E2E Tests *(in aiup-blazor-dotnet)*
-
-**Purpose:** Creates end-to-end browser tests in native C# using `Microsoft.Playwright.Xunit`, in a dedicated
-`*.Tests.E2E` project.
-
-**Usage:**
-
-```
-/playwright-test UC-001     # use case journey
-/playwright-test TC-001     # test case journey across views
-```
-
-**What it does:**
-
-1. Reads `docs/use_cases/UC-XXX-*.md` or `docs/test_cases/TC-XXX-*.md` to derive the journey
-2. Generates a test class inheriting from `Microsoft.Playwright.Xunit.PageTest`, hosted by a
-   `WebApplicationFactory<Program>`-style fixture on a dynamic port (or a configured base URL)
-3. Uses web-first locators (`GetByRole`, `GetByLabel`, `GetByTestId`) with async `Expect(...)` assertions, allowing
-   Blazor interactive hydration to complete before interacting
-4. Runs `dotnet test` to execute the suite against the application
-
-**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument  
-**Output:** Playwright test class in the `*.Tests.E2E` project  
-**Plugin:** `aiup-blazor-dotnet`
-
----
-
-### `/drizzle-migration` — Drizzle Schema & Migrations *(in aiup-nestjs-nextjs)*
-
-**Purpose:** Turns `docs/entity_model.md` into Drizzle ORM schema definitions and generated PostgreSQL
-migrations.
-
-**Usage:**
-
-```
-/drizzle-migration
-```
-
-**What it does:**
-
-1. Reads `docs/entity_model.md` and locates `drizzle.config.ts` to resolve the project's `schema` and `out` paths
-2. Edits the schema file with `pg-core` definitions, mapping entity attributes to column types and turning
-   validation rules into CHECK, UNIQUE, and index constraints
-3. Detects the project's existing money-column convention (`numeric` returns strings through `pg`,
-   `doublePrecision` returns numbers) and follows it rather than imposing one
-4. Runs `drizzle-kit generate` and reviews the emitted SQL — migrations are never hand-written, and an
-   already-applied migration is never edited
-5. Detects a desynchronised migration history (a hand-edited migration with a stale snapshot) and stops to
-   report it rather than generating DDL that could drop a populated column
-
-**Input:** `docs/entity_model.md`
-**Output:** Updated Drizzle schema plus a generated migration and journal entry under the configured `out` directory
-**Plugin:** `aiup-nestjs-nextjs`
-
----
-
-### `/implement` — Use Case Implementation *(in aiup-nestjs-nextjs)*
-
-**Purpose:** Implements a use case across a NestJS + Drizzle backend and a Next.js App Router frontend.
-
-**Usage:**
-
-```
-/implement UC-010
-```
-
-**What it does:**
-
-1. Detects the project layout — app roots, ESM/NodeNext, router style, route indirection, shared contract
-   package — before writing any code
-2. Creates a NestJS feature module (module, controller, service, repository, DTOs) with all SQL confined to the
-   repository and a mapped response DTO instead of raw database rows
-3. Adds `.js` suffixes to every relative import where the backend is NodeNext, and registers the module in the
-   root application module
-4. Implements the Next.js page, calling relative `/api/...` paths through the project's rewrite and using its
-   existing fetch client, component library, and shared types where present
-5. Reconciles an existing implementation with a changed specification instead of creating a parallel one
-
-**Input:** Use case ID as argument, `docs/use_cases/UC-XXX-*.md`, `docs/entity_model.md`
-**Output:** NestJS feature module under `src/<feature>/` and a Next.js page under `src/app/<route>/`
-**Plugin:** `aiup-nestjs-nextjs`
-
----
-
-### `/nest-test` — Backend Unit & E2E Tests *(in aiup-nestjs-nextjs)*
-
-**Purpose:** Creates Vitest unit specs and Supertest end-to-end specs that run against a real PostgreSQL
-database in Testcontainers.
-
-**Usage:**
-
-```
-/nest-test UC-010
-```
-
-**What it does:**
-
-1. Verifies `vitest.config.ts` registers `unplugin-swc` — without it NestJS dependency injection silently fails,
-   because Vitest's default transformer does not emit decorator metadata — and that `oxc: false` is set on Vite 8+
-2. Creates or verifies the Testcontainers global setup: one shared PostgreSQL container per run, with the schema
-   dropped and recreated per test file
-3. Writes unit specs with repositories stubbed against their real signatures, asserting mapping logic
-4. Writes Supertest e2e specs that boot the application in `beforeAll`, covering the main scenario, every
-   alternative flow, and each business rule, asserting status codes *and* response bodies
-5. Names `describe` blocks `UC-XXX: <Use Case Name>` so tests trace back to the specification
-
-**Input:** Use case ID as argument, `docs/use_cases/UC-XXX-*.md`
-**Output:** Unit specs under `src/**/*.spec.ts` and e2e specs under `test/**/*.e2e-spec.ts`
-**Plugin:** `aiup-nestjs-nextjs`
-
----
-
-### `/react-test` — React Component Tests *(in aiup-nestjs-nextjs)*
-
-**Purpose:** Creates Vitest + React Testing Library component tests for Next.js pages in jsdom.
-
-**Usage:**
-
-```
-/react-test UC-010
-```
-
-**What it does:**
-
-1. Identifies the real target component — where routes delegate to view components, the route file is a thin
-   wrapper that asserts nothing
-2. Mocks the project's fetch-client module rather than global `fetch`, so the test breaks when the client
-   contract changes
-3. Queries by role and accessible label, so a page failing the test also fails an accessibility audit
-4. Handles shadcn/Radix controls, which render comboboxes rather than native `<select>` elements
-5. Falls back to `fireEvent` when `@testing-library/user-event` is not a project dependency, rather than
-   importing a package that isn't installed
-
-**Input:** Use case ID as argument, `docs/use_cases/UC-XXX-*.md`
-**Output:** Component test file colocated with the component under test
-**Plugin:** `aiup-nestjs-nextjs`
-
----
-
-### `/playwright-test` — Browser E2E Tests *(in aiup-nestjs-nextjs)*
-
-**Purpose:** Creates Playwright end-to-end tests driving the Next.js frontend against a live NestJS API.
-
-**Usage:**
-
-```
-/playwright-test UC-010
-/playwright-test TC-001     # test case journey across several use cases
-```
-
-**What it does:**
-
-1. Reads `docs/test_cases/TC-XXX-*.md` where one covers the request, following its flow table step by step;
-   otherwise falls back to the use case's scenarios
-2. Configures `webServer` to boot both applications, waiting on a readiness endpoint rather than a bare port
-3. Uses accessibility-first locators (`getByRole`, `getByLabel`, `getByText`) and auto-retrying
-   `expect(locator)` assertions — never CSS selectors, XPath, or `waitForTimeout()`
-4. Reuses the project's existing authenticated `storageState` instead of logging in inside every test
-5. Creates test data through the API and removes exactly that data in `test.afterEach`, keeping tests
-   parallel-safe when they mutate application-wide state
-
-**Input:** Use case ID (`UC-*`) or test case ID (`TC-*`) as argument
-**Output:** Playwright spec under the project's e2e directory
-**Plugin:** `aiup-nestjs-nextjs`
-
----
-
-## Project Structure
-
-After running the full workflow for a project, your tree will look like this:
-
-```
-your-project/
+The skill inspects entry points, domain models, schema, authentication, and integrations, then proposes an entity
+model, use case diagram, and individual use case specifications. It reports behavior it cannot classify so the team
+can review gaps before adopting the result as a baseline.
+
+## Installation
+
+- [Claude Code](docs/installation/claude-code.md) — add the marketplace and install plugins directly.
+- [Tessl](docs/installation/tessl.md) — install pinned plugins for one or more supported agents.
+- [Agent Plugins and manual setup](docs/installation/other-agents.md) — direct packages, skill locations, MCP examples,
+  and host-specific caveats.
+
+Every plugin directory contains:
+
+- a Claude Code manifest and MCP configuration;
+- an Agent Plugins v1.0.0 `plugin.json` and `mcp.json`;
+- portable Agent Skills under `skills/`;
+- a Tessl package manifest;
+- evaluation scenarios used during publication.
+
+CI keeps the three plugin manifest formats and their MCP definitions in sync.
+
+## Documentation
+
+| Guide                                                        | Contents                                                                          |
+|--------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| [Getting started](docs/getting-started.md)                   | Select plugins, prepare a vision, install AIUP, and create the first artifacts    |
+| [Workflow and artifacts](docs/workflow.md)                   | Phases, traceability, artifact ownership, changes, and legacy projects            |
+| [Project setup](docs/guides/project-setup.md)                | Recommended project documentation tree and agent guidance                         |
+| [Vision template](docs/templates/vision.md)                  | Starting point for `docs/vision.md`                                               |
+| [CLAUDE.md template](docs/templates/CLAUDE.md)               | Stack-neutral repository instructions for Claude Code                             |
+| [Complete tutorial](https://unifiedprocess.ai/tutorial.html) | Book Library example: stack-neutral analysis followed by Vaadin/jOOQ construction |
+
+Detailed skill behavior is documented in each plugin's `skills/*/SKILL.md`. Those files are the authoritative source
+for inputs, outputs, safety constraints, and execution steps; READMEs provide navigation and concise summaries.
+
+## Repository layout
+
+```text
+marketplace/
+├── aiup-core/
+├── aiup-vaadin-jooq/
+├── aiup-angular-jpa/
+├── aiup-blazor-dotnet/
+├── aiup-nestjs-nextjs/
 ├── docs/
-│   ├── vision.md                         ← you maintain this
-│   ├── requirements.md                   ← produced by /requirements
-│   ├── entity_model.md                   ← produced by /entity-model
-│   ├── use_cases.puml                    ← produced by /use-case-diagram
-│   ├── use_cases/                        ← produced by /use-case-spec
-│   │   ├── UC-001-create-reservation.md
-│   │   ├── UC-002-cancel-reservation.md
-│   │   └── ...
-│   └── test_cases/                       ← produced by /test-case — journeys for /playwright-test TC-*
-│       └── TC-001-book-and-check-in.md
-├── src/
-│   ├── main/
-│   │   ├── java/                         ← produced by /implement
-│   │   └── resources/
-│   │       └── db/migration/             ← produced by /flyway-migration
-│   │           ├── V001__create_room_type_table.sql
-│   │           └── ...
-│   └── test/
-│       ├── java/                         ← produced by /browserless-test, /playwright-test
-│       └── resources/
-│           └── db/migration/             ← test data seeds
-└── CLAUDE.md
+└── scripts/
 ```
 
-The tree above shows the Vaadin/jOOQ shape. `aiup-angular-jpa` supports that same flat split *or* a hexagonal multi-module
-Maven reactor (`domain`/`business`/`postgres`/`api`/`app`), detected automatically. `aiup-blazor-dotnet` keeps the same
-`docs/` tree but organizes code as vertical slices — one `Features/UCXXX_<FeatureName>/` folder per use case holding
-the Blazor page, code-behind, scoped CSS, command/query, handler, and validator — with EF Core migrations under
-`Migrations/` and tests split across a bUnit/xUnit project and a `*.Tests.E2E` Playwright project.
-`aiup-nestjs-nextjs` keeps the same `docs/` tree over a split TypeScript workspace — a NestJS API whose features are
-folders of module/controller/service/repository/DTOs with Drizzle migrations under `drizzle/migrations/`, and a
-Next.js App Router frontend — with tests split across Vitest unit specs, Supertest e2e specs on Testcontainers,
-React Testing Library component tests, and Playwright. See each plugin's
-own README for its exact project-structure tree.
+## Learn more
 
----
+Visit [unifiedprocess.ai](https://unifiedprocess.ai) for the broader methodology.
 
-## Recommended CLAUDE.md
+## License
 
-Create a `CLAUDE.md` at your project root. Claude loads this automatically at the start of every session:
-
-```markdown
-# Project Context
-
-This project follows the AI Unified Process. Read `docs/vision.md`, `docs/requirements.md`,
-and `docs/entity_model.md` for product context before making decisions.
-
-## AI Unified Process Workflow
-
-1. `/requirements`        → derives `docs/requirements.md` from `docs/vision.md`
-2. `/entity-model`        → derives `docs/entity_model.md` from requirements
-3. `/use-case-diagram`    → produces `docs/use_cases.puml`
-4. `/use-case-spec UC-XX` → produces `docs/use_cases/UC-XX-*.md`
-5. `/flyway-migration`    → produces `src/main/resources/db/migration/V*.sql`
-6. `/implement UC-XX`     → implements the use case (Vaadin + jOOQ)
-7. `/browserless-test UC-XX` → server-side unit tests (recommended, free since Vaadin 25.1)
-8. `/playwright-test UC-XX` → browser-based integration tests (or `TC-XX` for an end-to-end journey)
-
-Never skip the spec for a use case before implementing it.
-Always read the entity model before writing data access code.
-```
-
----
-
-## Recommended `docs/vision.md` Structure
-
-The `/requirements` skill relies heavily on this file. Include at minimum:
-
-```markdown
-# Vision: <Product Name>
-
-## Mission
-
-<One paragraph on what this product does and the problem it solves.>
-
-## Target Users
-
-- <Primary user role and what they need from the system>
-- <Secondary user roles>
-
-## Goals
-
-- <Measurable business or product goals>
-
-## Scope
-
-- In scope: <high-level capabilities>
-- Out of scope: <explicit non-goals>
-
-## Constraints
-
-- <Regulatory, technical, organizational constraints>
-```
-
----
-
-## Tips
-
-**Maintain traceability.** Every entity should map to at least one functional requirement; every use case should trace
-to one or more FRs; every test should reference a use case ID. The skills produce stable IDs (FR-001, UC-001, …) — keep
-them.
-
-**Edit between steps.** The intermediate documents (`requirements.md`, `entity_model.md`, `use_cases.puml`) are designed
-to be reviewed and corrected by hand. Do not skip the review.
-
-**Re-run upstream skills when requirements change.** If a new functional requirement appears, re-run `/entity-model` and
-`/use-case-diagram` so the downstream artifacts stay consistent. Re-running is cheap; fixing inconsistencies later is
-not.
-
-**Keep `aiup-core` even on non-Vaadin stacks.** The methodology skills are stack-agnostic — only the construction-phase
-skills are tied to Vaadin/jOOQ. You can pair `aiup-core` with any implementation toolchain.
-
-**Commit `docs/` to version control.** The vision, requirements, entity model, and use case specs are your project's
-institutional memory — they explain *why* the code is the way it is, which is invaluable for onboarding and debugging
-months later.
-
----
-
-## Learn More
-
-Visit [unifiedprocess.ai](https://unifiedprocess.ai) for the full methodology.
-
-## Key Concepts
-
-### Marketplace
-
-A **marketplace** is a curated repository that hosts and distributes multiple Claude Code plugins. It acts as a central
-hub where plugins can be discovered, installed, and managed. When you add a marketplace to Claude Code, you gain access
-to all the plugins it contains.
-
-### Plugin
-
-A **plugin** is a self-contained extension that adds new capabilities to Claude Code. Each plugin can include skills,
-agents, hooks, and MCP servers. Plugins are technology-specific and encapsulate everything needed to work with a
-particular tech stack or methodology.
-
-### Skill
-
-A **skill** is a specialized behavior defined in a `SKILL.md` file. Skills can be invoked explicitly as slash commands (
-e.g., `/requirements`) or triggered automatically by Claude when it recognizes a matching task. Skills are namespaced by
-their plugin (e.g., `aiup-core:requirements`).
-
-### MCP Server
-
-An **MCP (Model Context Protocol) server** is an external service that provides Claude with access to specialized tools
-and documentation. The plugins in this marketplace ship with the following servers:
-
-| Server             | Plugin                                                        | Description                                        |
-|--------------------|---------------------------------------------------------------|----------------------------------------------------|
-| **context7**       | `aiup-core`                                                   | General library documentation lookup               |
-| **Vaadin**         | `aiup-vaadin-jooq`                                            | Vaadin component and framework documentation       |
-| **KaribuTesting**  | `aiup-vaadin-jooq`                                            | Karibu testing framework documentation             |
-| **jOOQ**           | `aiup-vaadin-jooq`                                            | jOOQ DSL and code generation reference             |
-| **JavaDocs**       | `aiup-vaadin-jooq`, `aiup-angular-jpa`                        | Java API documentation lookup                      |
-| **MicrosoftLearn** | `aiup-blazor-dotnet`                                          | .NET, Blazor, and EF Core documentation lookup     |
-| **bUnitDocs**      | `aiup-blazor-dotnet`                                          | bUnit component testing documentation              |
-| **Playwright**     | `aiup-vaadin-jooq`, `aiup-angular-jpa`, `aiup-blazor-dotnet`, `aiup-nestjs-nextjs` | Browser automation for integration tests |
+Licensed under the [Apache License 2.0](LICENSE).

--- a/aiup-angular-jpa/.claude-plugin/plugin.json
+++ b/aiup-angular-jpa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-angular-jpa",
-  "description": "AI Unified Process plugin for the Angular/JPA stack",
-  "version": "0.2.1",
+  "description": "AI Unified Process for the Angular/JPA stack - migrations, implementation, tests",
+  "version": "0.2.2",
   "author": {
     "name": "Marc Affolter",
     "email": "marc_affolter@outlook.com",

--- a/aiup-angular-jpa/.tessl-plugin/plugin.json
+++ b/aiup-angular-jpa/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-unified-process/aiup-angular-jpa",
-  "description": "AI Unified Process plugin for the Angular/JPA stack",
-  "version": "0.2.1",
+  "description": "AI Unified Process for the Angular/JPA stack - migrations, implementation, tests",
+  "version": "0.2.2",
   "rules": "rules",
   "author": {
     "name": "Marc Affolter",

--- a/aiup-angular-jpa/README.md
+++ b/aiup-angular-jpa/README.md
@@ -1,56 +1,35 @@
 # aiup-angular-jpa
 
-> The Angular + JPA stack plugin for the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) — turns use
-> case specifications into an implemented, tested Spring Boot API and Angular frontend.
+`aiup-angular-jpa` is the AIUP construction plugin for an [Angular](https://angular.dev) frontend and a
+[Spring Boot](https://spring.io/projects/spring-boot) backend using JPA/Hibernate. It turns the artifacts produced by
+[`aiup-core`](../aiup-core/) into database migrations, a REST API, an Angular UI, and tests across both applications.
 
-`aiup-angular-jpa` is the **technology-specific** layer of the AI Unified Process for applications with a
-[Spring Boot](https://spring.io/projects/spring-boot) + [JPA/Hibernate](https://hibernate.org) backend and an
-[Angular](https://angular.dev) frontend. It takes the artifacts produced by
-[`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) — the entity model and use case specifications — and
-turns them into database migrations, a REST API, an Angular UI, and a full test suite across both halves of the
-stack.
+This plugin is designed to continue from the specifications produced by `aiup-core`. For the complete AIUP workflow,
+use it alongside `aiup-core` and select one stack plugin.
 
-Unlike a server-rendered UI framework, this is a **split client/server architecture**: the backend and frontend are
-independent builds that only share a JSON contract over HTTP. Every skill in this plugin reflects that split.
+## Architecture support
 
-## What makes this plugin different from `aiup-vaadin-jooq`
-Besides the obvious frontend swap, this plugin's backend skills (`/implement`, `/flyway-migration`,
-`/spring-boot-test`) **detect and support two backend shapes**, rather than assuming one:
+The backend skills detect and follow either of these established project shapes:
 
-- **Flat single-module** — one Spring Boot project with `@Entity`/repository/service/controller together.
-- **Hexagonal multi-module** — a Maven reactor with separate `domain` / `business` / persistence-adapter /
-  inbound-adapter / composition-root modules (ports and adapters enforced at the module boundary, not just by
-  package naming). This is a common, deliberate architectural choice for larger Spring Boot backends, and the
-  skills detect it and follow its existing conventions (including asymmetric ones — e.g. an outbound-only port,
-  no inbound use-case interface) rather than forcing every project into one shape.
+- **Flat single module:** entities, repositories, services, and controllers in one Spring Boot module.
+- **Hexagonal multi-module:** separate domain, business, persistence adapter, inbound adapter, and composition-root
+  modules with ports and adapters enforced by Maven boundaries.
 
-See [`skills/implement/references/module-layout.md`](skills/implement/references/module-layout.md) for the
-detection heuristic shared by all three skills.
+Existing asymmetric conventions are preserved instead of being rewritten into a textbook architecture. The shared
+detection rules are documented in
+[`skills/implement/references/module-layout.md`](skills/implement/references/module-layout.md).
 
-## What it does
+## Skills and workflow
 
-This plugin covers the **Construction** phase of the AI Unified Process for the Angular/JPA stack: schema
-migrations, backend and frontend implementation, and testing on both sides — with every artifact traceable back to
-a use case (`UC-*`).
+| Phase        | Skill                                                   | Result                                                             |
+|--------------|---------------------------------------------------------|--------------------------------------------------------------------|
+| Construction | [`/flyway-migration`](skills/flyway-migration/SKILL.md) | Flyway migrations placed in the detected persistence module        |
+| Construction | [`/implement`](skills/implement/SKILL.md)               | Spring Boot API and Angular UI following the existing architecture |
+| Construction | [`/spring-boot-test`](skills/spring-boot-test/SKILL.md) | Backend integration tests using the project's detected convention  |
+| Construction | [`/vitest-test`](skills/vitest-test/SKILL.md)           | Angular component tests with TestBed and HttpTestingController     |
+| Construction | [`/playwright-test`](skills/playwright-test/SKILL.md)   | Browser-based end-to-end tests for the split application           |
 
-It is meant to be used **together with `ai-unified-process/aiup-core`**, which produces the upstream `docs/entity_model.md` and
-`docs/use_cases/UC-*.md` artifacts these skills read. It is **not meant to be used together with `ai-unified-process/aiup-vaadin-jooq**,
-
-## Skills
-
-Each skill is also available as a slash command.
-
-| Phase        | Skill / command     | Description                                                                                |
-|--------------|---------------------|--------------------------------------------------------------------------------------------|
-| Construction | `/flyway-migration` | Create versioned Flyway migration scripts (`V*.sql`) from the entity model                 |
-| Construction | `/implement`        | Implement use cases across a flat or hexagonal Spring Boot backend and an Angular frontend |
-| Construction | `/spring-boot-test` | Create Spring Boot tests (RestAssured+Testcontainers or MockMvc, auto-detected)            |
-| Construction | `/vitest-test`      | Create Vitest component tests using Angular's own TestBed/HttpTestingController idioms     |
-| Construction | `/playwright-test`  | Create Playwright browser-based end-to-end tests                                           |
-
-### Workflow
-
-```
+```text
 Construction
 ──────────────────────────────────────────────────────
 /flyway-migration  →  /implement  →  /spring-boot-test
@@ -58,83 +37,99 @@ Construction
                                   ↘  /playwright-test
 ```
 
-These skills read the AI Unified Process artifacts under `docs/` (`docs/entity_model.md`, `docs/use_cases/UC-*.md`) produced by
-`ai-unified-process/aiup-core` and write code and tests into your backend (Maven/Gradle, flat or multi-module) and frontend
-(npm/Angular CLI) projects.
-
-## MCP servers
-
-| Server      | Purpose                                                                                  |
-|-------------|------------------------------------------------------------------------------------------|
-| JavaDocs    | Javadoc lookup for Spring/Hibernate/RestAssured/Testcontainers on the classpath          |
-| Playwright  | Browser automation for end-to-end tests                                                  |
-
-RxJS and Vitest docs are covered by `aiup-core`'s **context7**
-MCP server. See [`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
+The linked `SKILL.md` files are the authoritative reference for detailed inputs, outputs, and behavior.
 
 ## Installation
 
-Install from the Tessl registry (install the core plugin too, if you haven't already):
+### Tessl
 
+Initialize the project once:
+
+```sh
+tessl init --agent agents
 ```
+
+`agents` is the vendor-neutral layout; use `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode`
+for a specific host. Then install the plugins:
+
+```sh
 tessl install ai-unified-process/aiup-core
 tessl install ai-unified-process/aiup-angular-jpa
 ```
 
+Depending on the configured agent, skills may be exposed as slash commands or invoked by intent, for example
+"implement UC-001".
+
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
+/plugin install aiup-angular-jpa
+```
+
+See the marketplace [installation guides](../docs/getting-started.md) for other agents and manual adoption.
+
 ## Prerequisites
 
-- [`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) installed, with use case specifications and an
-  entity model already produced under `docs/`
-- A Maven or Gradle backend project with Spring Boot, Spring Data JPA, and Flyway — either a flat single module,
-  or a hexagonal `domain`/`business`/persistence-adapter/inbound-adapter/composition-root-style multi-module
-  layout
-- An Angular (standalone components) frontend project
-- Optional MCP servers (JavaDocs, Playwright) configured per [`rules/mcp-servers.md`](rules/mcp-servers.md)
+- `aiup-core` and reviewed `docs/entity_model.md` plus `docs/use_cases/UC-*.md` artifacts.
+- A Maven or Gradle backend with Spring Boot, Spring Data JPA, and Flyway.
+- An Angular frontend using standalone components.
+- Docker when the project's integration-test convention uses Testcontainers.
+- Optional MCP servers configured through [`rules/mcp-servers.md`](rules/mcp-servers.md).
 
-## Project Structure
+## Inputs and generated artifacts
 
-### Flat single-module backend
+All construction skills consume the core artifacts under `docs/`. They write migrations and backend code into the
+detected Spring module, Angular pages and services into the existing frontend layout, and tests alongside their
+respective application.
 
-```
+## Project structure
+
+### Flat backend
+
+```text
 your-project/
 ├── docs/
-│   └── ...
 ├── backend/
-│   ├── src/
-│   │   ├── main/
-│   │   │   ├── java/                     ← produced by /implement (entity, repository, service, controller)
-│   │   │   └── resources/
-│   │   │       └── db/migration/         ← produced by /flyway-migration
-│   │   └── test/
-│   │       ├── java/                     ← produced by /spring-boot-test
-│   │       └── resources/db/migration/   ← test data seeds (MockMvc convention only)
-│   └── pom.xml
+│   └── src/
+│       ├── main/java/                    # /implement
+│       ├── main/resources/db/migration/  # /flyway-migration
+│       └── test/java/                    # /spring-boot-test
 └── frontend/
-    ├── src/app/                           ← produced by /implement (pages, components, services)
-    ├── tests/e2e/                         ← produced by /playwright-test
-    └── package.json
+    ├── src/app/                          # /implement and /vitest-test
+    └── tests/e2e/                        # /playwright-test
 ```
 
-### Hexagonal multi-module backend
+### Hexagonal backend
 
+```text
+backend/
+├── <domain-module>/                      # pure domain types
+├── <business-module>/                    # services, ports, and DTOs
+├── <persistence-module>/                 # JPA adapter and Flyway migrations
+├── <api-module>/                         # REST controllers
+└── <app-module>/                         # composition root and integration tests
 ```
-your-project/
-├── docs/
-│   └── ...
-├── backend/
-│   ├── pom.xml                           ← reactor
-│   ├── xxx-domain/                       ← pure domain records, zero framework deps
-│   ├── xxx-business/                     ← services, outbound port interfaces, DTOs
-│   ├── xxx-postgres/                     ← JPA entities, converters, Spring Data repos
-│   │   └── src/main/resources/db/migration/  ← produced by /flyway-migration
-│   ├── xxx-api/                          ← REST controllers
-│   └── xxx-app/                          ← composition root
-│       └── src/test/java/                ← produced by /spring-boot-test (only module with tests)
-└── frontend/
-    ├── src/app/                           ← produced by /implement (pages, components, services)
-    ├── tests/e2e/                         ← produced by /playwright-test
-    └── package.json
-```
+
+Module names and frontend locations are detected from the project; these trees illustrate responsibilities rather
+than prescribe exact names.
+
+## MCP servers
+
+| Server       | Purpose                                                            |
+|--------------|--------------------------------------------------------------------|
+| `JavaDocs`   | Spring, Hibernate, RestAssured, Testcontainers, and classpath APIs |
+| `playwright` | Browser automation                                                 |
+
+General npm package documentation is available through `aiup-core`'s `context7` server. See
+[`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
+
+## Related documentation
+
+- [Getting started](../docs/getting-started.md)
+- [Workflow and artifacts](../docs/workflow.md)
+- [`aiup-core`](../aiup-core/)
 
 ## License
 

--- a/aiup-angular-jpa/plugin.json
+++ b/aiup-angular-jpa/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aiup-angular-jpa",
-  "version": "0.2.1",
-  "description": "AI Unified Process plugin for the Angular/JPA stack",
+  "version": "0.2.2",
+  "description": "AI Unified Process for the Angular/JPA stack - migrations, implementation, tests",
   "author": {
     "name": "Marc Affolter",
     "email": "marc_affolter@outlook.com",

--- a/aiup-blazor-dotnet/.claude-plugin/plugin.json
+++ b/aiup-blazor-dotnet/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-blazor-dotnet",
-  "description": "AI Unified Process plugin for C# and Blazor on .NET 10",
-  "version": "0.3.0",
+  "description": "AI Unified Process for the C# / Blazor .NET 10 stack - migrations, implementation, tests",
+  "version": "0.3.1",
   "author": {
     "name": "Carl J. Mosca",
     "email": "carljmosca@gmail.com",

--- a/aiup-blazor-dotnet/.tessl-plugin/plugin.json
+++ b/aiup-blazor-dotnet/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-unified-process/aiup-blazor-dotnet",
-  "description": "AI Unified Process plugin for C# and Blazor on .NET 10",
-  "version": "0.3.0",
+  "description": "AI Unified Process for the C# / Blazor .NET 10 stack - migrations, implementation, tests",
+  "version": "0.3.1",
   "rules": "rules",
   "author": {
     "name": "Carl J. Mosca",

--- a/aiup-blazor-dotnet/README.md
+++ b/aiup-blazor-dotnet/README.md
@@ -1,29 +1,113 @@
 # aiup-blazor-dotnet
 
-> Stack-specific plugin of the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) for **C# and Blazor on .NET 10**.
+`aiup-blazor-dotnet` is the AIUP construction plugin for C#, Blazor, and Entity Framework Core on .NET 10. It turns
+the entity model and use case specifications produced by [`aiup-core`](../aiup-core/) into EF Core migrations,
+Vertical Slice features, and tests using bUnit, xUnit, and Playwright.
 
-`aiup-blazor-dotnet` provides implementation and testing skills for projects built with C#, EF Core, Blazor (.NET 10), bUnit, and Playwright. It consumes the specifications produced by [`aiup-core`](../aiup-core).
+This plugin is designed to continue from the specifications produced by `aiup-core`. For the complete AIUP workflow,
+use it alongside `aiup-core` and select one stack plugin.
 
-## Skills
+## Skills and workflow
 
-| Phase        | Skill / command    | Description                                                               |
-|--------------|--------------------|---------------------------------------------------------------------------|
-| Construction | `/ef-migration`    | Generate native EF Core C# migrations based on `docs/entity_model.md`     |
-| Construction | `/implement`       | Implement use cases using C# Vertical Slice Architecture                  |
-| Construction | `/bunit-test`      | Create bUnit UI component tests for Blazor `.razor` pages                 |
-| Construction | `/dotnet-test`     | Create backend unit and integration tests for EF Core and domain handlers |
-| Construction | `/playwright-test` | Create native C# Playwright E2E browser tests (`Microsoft.Playwright.Xunit`)|
+| Phase        | Skill                                                 | Result                                                     |
+|--------------|-------------------------------------------------------|------------------------------------------------------------|
+| Construction | [`/ef-migration`](skills/ef-migration/SKILL.md)       | EF Core entities, configurations, and generated migrations |
+| Construction | [`/implement`](skills/implement/SKILL.md)             | Blazor use case implemented as a Vertical Slice            |
+| Construction | [`/bunit-test`](skills/bunit-test/SKILL.md)           | Browserless component tests for `.razor` pages             |
+| Construction | [`/dotnet-test`](skills/dotnet-test/SKILL.md)         | Backend unit and relational integration tests              |
+| Construction | [`/playwright-test`](skills/playwright-test/SKILL.md) | Native C# browser tests for `UC-*` or `TC-*` journeys      |
+
+```text
+Construction
+─────────────────────────────────────────────────
+/ef-migration  →  /implement  →  /bunit-test
+                              ↘  /dotnet-test
+                              ↘  /playwright-test
+```
+
+The linked `SKILL.md` files are the authoritative reference for detailed inputs, outputs, and behavior.
 
 ## Installation
 
-Install from the Tessl registry:
+### Tessl
 
-```bash
+Initialize the project once:
+
+```sh
+tessl init --agent agents
+```
+
+`agents` is the vendor-neutral layout; use `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode`
+for a specific host. Then install the plugins:
+
+```sh
+tessl install ai-unified-process/aiup-core
 tessl install ai-unified-process/aiup-blazor-dotnet
 ```
 
-Or via Claude Code marketplace:
+Depending on the configured agent, skills may be exposed as slash commands or invoked by intent, for example
+"implement UC-001".
 
-```bash
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
 /plugin install aiup-blazor-dotnet
 ```
+
+See the marketplace [installation guides](../docs/getting-started.md) for other agents and manual adoption.
+
+## Prerequisites
+
+- `aiup-core` and reviewed `docs/entity_model.md` plus `docs/use_cases/UC-*.md` artifacts.
+- A .NET 10 solution or project using Blazor and Entity Framework Core.
+- A configured relational database provider and EF Core tooling for migrations.
+- Node.js and installed Playwright browsers when browser tests are generated.
+- Optional MCP servers configured through [`rules/mcp-servers.md`](rules/mcp-servers.md).
+
+## Inputs and generated artifacts
+
+The plugin consumes the core documentation under `docs/`. It updates EF Core persistence types, creates migration
+files, implements a feature folder per use case, and places bUnit, backend, and browser tests in the solution's test
+projects.
+
+## Project structure
+
+```text
+your-solution/
+├── docs/
+│   ├── entity_model.md
+│   ├── use_cases/UC-*.md
+│   └── test_cases/TC-*.md
+├── <Application>/
+│   ├── Data/                            # DbContext and EF configurations
+│   ├── Migrations/                      # /ef-migration
+│   └── Features/
+│       └── UCXXX_<FeatureName>/         # /implement
+├── <Application>.Tests/                 # /bunit-test and /dotnet-test
+└── <Application>.Tests.E2E/             # /playwright-test
+```
+
+A feature folder can contain the Blazor page, code-behind, scoped CSS, command or query, handler, and validator. The
+skills inspect existing project and test conventions before selecting exact names and paths.
+
+## MCP servers
+
+| Server           | Purpose                                                       |
+|------------------|---------------------------------------------------------------|
+| `MicrosoftLearn` | Current .NET, Blazor, and Entity Framework Core documentation |
+| `bUnitDocs`      | bUnit component-testing documentation                         |
+| `playwright`     | Browser automation                                            |
+
+See [`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
+
+## Related documentation
+
+- [Getting started](../docs/getting-started.md)
+- [Workflow and artifacts](../docs/workflow.md)
+- [`aiup-core`](../aiup-core/)
+
+## License
+
+Apache-2.0 · © [Carl J. Mosca](https://unifiedprocess.ai)

--- a/aiup-blazor-dotnet/plugin.json
+++ b/aiup-blazor-dotnet/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aiup-blazor-dotnet",
-  "version": "0.3.0",
-  "description": "AI Unified Process plugin for C# and Blazor on .NET 10",
+  "version": "0.3.1",
+  "description": "AI Unified Process for the C# / Blazor .NET 10 stack - migrations, implementation, tests",
   "author": {
     "name": "Carl J. Mosca",
     "email": "carljmosca@gmail.com",

--- a/aiup-core/.claude-plugin/plugin.json
+++ b/aiup-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-core",
-  "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)",
-  "version": "2.5.0",
+  "description": "AI Unified Process core - stack-agnostic requirements, entity model, and use cases",
+  "version": "2.5.1",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-core/.tessl-plugin/plugin.json
+++ b/aiup-core/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-unified-process/aiup-core",
-  "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)",
-  "version": "2.5.0",
+  "description": "AI Unified Process core - stack-agnostic requirements, entity model, and use cases",
+  "version": "2.5.1",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-core/README.md
+++ b/aiup-core/README.md
@@ -1,80 +1,105 @@
 # aiup-core
 
-> Stack-agnostic core of the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) — a structured,
-> requirements-first workflow for taking a software project from raw vision to use case specifications.
+`aiup-core` is the stack-independent foundation of the
+[AI Unified Process](https://unifiedprocess.ai). It turns a product vision into requirements, an entity model, use
+cases, and test journeys that stack-specific plugins can implement.
 
-`aiup-core` is the foundation plugin of the AI Unified Process. It is **technology-independent**: it works with any
-language, framework, or stack because it stops at the specification boundary. Implementation and testing are handled by
-stack-specific plugins (e.g. [`ai-unified-process/aiup-vaadin-jooq`](https://registry.tessl.io/ai-unified-process/aiup-vaadin-jooq)) that build on
-the artifacts this plugin produces.
+Use this plugin for every AIUP project. It works with any programming language because its output boundary is a set of
+reviewable files under `docs/`.
 
-## What it does
+## Skills and workflow
 
-The plugin automates the analysis phases of the AI Unified Process, adapted from the
-[Rational Unified Process](https://en.wikipedia.org/wiki/Rational_unified_process) — **Inception → Elaboration →
-Construction**. Every project starts from a written vision and proceeds through requirements, an entity model, and use
-case specifications. Nothing gets built without a use case.
+| Phase        | Skill                                                   | Result                                                         |
+|--------------|---------------------------------------------------------|----------------------------------------------------------------|
+| Inception    | [`/requirements`](skills/requirements/SKILL.md)         | Requirements catalog derived from `docs/vision.md`             |
+| Elaboration  | [`/entity-model`](skills/entity-model/SKILL.md)         | Mermaid entity model and attribute definitions                 |
+| Elaboration  | [`/use-case-diagram`](skills/use-case-diagram/SKILL.md) | PlantUML diagram of actors and use cases                       |
+| Construction | [`/use-case-spec`](skills/use-case-spec/SKILL.md)       | One detailed specification per use case                        |
+| Construction | [`/test-case`](skills/test-case/SKILL.md)               | Executable journey across multiple specified use cases         |
+| Any          | [`/reverse-engineer`](skills/reverse-engineer/SKILL.md) | Entity and use case documentation recovered from existing code |
 
-This prevents the most common failure mode of AI-assisted development: jumping straight to code from a vague prompt and
-producing something that half-works and can't be maintained.
-
-## Skills
-
-Each skill is also available as a slash command. Skills pick up where the previous one left off by reading the files
-written along the way, so you can inspect or edit any artifact before continuing.
-
-| Phase        | Skill / command       | Description                                                              |
-|--------------|-----------------------|--------------------------------------------------------------------------|
-| Inception    | `/requirements`       | Generate a structured requirements catalog (user stories, NFRs, constraints) from `docs/vision.md` |
-| Elaboration  | `/entity-model`       | Create an entity model with a Mermaid ER diagram and attribute tables    |
-| Elaboration  | `/use-case-diagram`   | Generate a PlantUML use case diagram mapping actors to use cases         |
-| Construction | `/use-case-spec`      | Write detailed use case specifications (flows, pre/postconditions, rules)|
-| Any          | `/reverse-engineer`   | Recover use case diagram, use case specs, and entity model from existing code |
-
-### Workflow
-
-```
-Inception          Elaboration                          Construction
-─────────────────  ──────────────────────────────────   ─────────────────
-/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec
+```text
+Inception          Elaboration                             Construction 
+─────────────     ───────────────────────────────────     ─────────────────────────────
+/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  /test-case
 ```
 
-The skills produce and consume a set of artifacts under `docs/`:
-
-- `docs/vision.md` — *input you provide* (product vision, target users, goals)
-- `docs/requirements.md`
-- `docs/entity_model.md`
-- `docs/use_cases.puml`
-- `docs/use_cases/UC-*.md`
-
-**Inheriting a legacy codebase?** Start with `/reverse-engineer` — it walks the existing code, configuration, and
-schema and produces the same `docs/use_cases.puml`, `docs/use_cases/UC-*.md`, and `docs/entity_model.md` artifacts the
-forward workflow would have produced, giving you a documented baseline to work from.
-
-## MCP servers
-
-| Server     | Purpose                                                                 |
-|------------|-------------------------------------------------------------------------|
-| context7   | Fetches current library/framework documentation on demand during analysis |
+Each skill reads the artifacts created by earlier steps. The linked `SKILL.md` files are the authoritative reference
+for detailed inputs, outputs, and behavior.
 
 ## Installation
 
-Install from the Tessl registry:
+### Tessl
 
+Initialize the project once:
+
+```sh
+tessl init --agent agents
 ```
+
+`agents` is the vendor-neutral layout; use `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode`
+for a specific host. Then install the plugin:
+
+```sh
 tessl install ai-unified-process/aiup-core
 ```
 
+Depending on the configured agent, skills may be exposed as slash commands or invoked by intent, for example
+"create the requirements catalog".
+
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
+```
+
+See the marketplace [installation guides](../docs/getting-started.md) for other agents and manual adoption.
+
 ## Prerequisites
 
-- A `docs/vision.md` file at the root of your project describing the product vision, target users, and high-level
-  goals. The `/requirements` skill reads this file to derive your requirements catalog — the richer it is, the better
-  the results.
+For the forward workflow, create `docs/vision.md` in the target project. It should describe the product mission,
+target users, goals, scope, and constraints. The marketplace provides a
+[vision template](../docs/templates/vision.md).
 
-## Next step
+Existing projects can begin with `/reverse-engineer` instead of a vision document.
 
-Once your use case specifications exist, add a stack-specific plugin to implement and test them — for example
-[`ai-unified-process/aiup-vaadin-jooq`](https://registry.tessl.io/ai-unified-process/aiup-vaadin-jooq) for the Vaadin + jOOQ stack.
+## Inputs and generated artifacts
+
+```text
+your-project/
+└── docs/
+    ├── vision.md                    # maintained by the team
+    ├── requirements.md              # /requirements
+    ├── entity_model.md              # /entity-model
+    ├── use_cases.puml               # /use-case-diagram
+    ├── use_cases/
+    │   └── UC-001-*.md              # /use-case-spec
+    └── test_cases/
+        └── TC-001-*.md              # /test-case
+```
+
+Review and commit these files with the source code. Stack plugins consume the entity model, use case specifications,
+and test journeys without depending on which coding agent produced them.
+
+## Project structure
+
+`aiup-core` does not impose a source-code layout. It writes only to the documentation paths above and inspects an
+existing source tree when `/reverse-engineer` runs. The selected stack plugin detects or documents the implementation
+layouts it supports.
+
+## MCP servers
+
+| Server     | Purpose                                                          |
+|------------|------------------------------------------------------------------|
+| `context7` | Current language, framework, and library documentation on demand |
+
+## Related documentation
+
+- [Getting started](../docs/getting-started.md)
+- [Workflow and artifacts](../docs/workflow.md)
+- [Project setup](../docs/guides/project-setup.md)
+- [Choose a stack plugin](../README.md#choose-your-plugins)
 
 ## License
 

--- a/aiup-core/plugin.json
+++ b/aiup-core/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aiup-core",
-  "version": "2.5.0",
-  "description": "AI Unified Process - stack-agnostic core methodology (requirements, entity model, use cases)",
+  "version": "2.5.1",
+  "description": "AI Unified Process core - stack-agnostic requirements, entity model, and use cases",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-nestjs-nextjs/.claude-plugin/plugin.json
+++ b/aiup-nestjs-nextjs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-nestjs-nextjs",
-  "description": "AI Unified Process plugin for the NestJS/Drizzle + Next.js stack",
-  "version": "0.1.0",
+  "description": "AI Unified Process for the NestJS/Drizzle + Next.js stack - migrations, implementation, tests",
+  "version": "0.1.1",
   "author": {
     "name": "Swift Ugandan",
     "email": "swiftugandan@gmail.com",

--- a/aiup-nestjs-nextjs/.tessl-plugin/plugin.json
+++ b/aiup-nestjs-nextjs/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-unified-process/aiup-nestjs-nextjs",
-  "description": "AI Unified Process plugin for the NestJS/Drizzle + Next.js stack",
-  "version": "0.1.0",
+  "description": "AI Unified Process for the NestJS/Drizzle + Next.js stack - migrations, implementation, tests",
+  "version": "0.1.1",
   "rules": "rules",
   "author": {
     "name": "Swift Ugandan",

--- a/aiup-nestjs-nextjs/README.md
+++ b/aiup-nestjs-nextjs/README.md
@@ -1,67 +1,38 @@
 # aiup-nestjs-nextjs
 
-> The NestJS + Next.js stack plugin for the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) —
-> turns use case specifications into an implemented, tested NestJS API and Next.js frontend.
+`aiup-nestjs-nextjs` is the AIUP construction plugin for a NestJS API using Drizzle ORM over PostgreSQL and a Next.js
+App Router frontend. It turns the artifacts produced by [`aiup-core`](../aiup-core/) into schema migrations, a REST
+API, a web UI, and tests across both applications.
 
-`aiup-nestjs-nextjs` is the **technology-specific** layer of the AI Unified Process for
-applications with a [NestJS](https://nestjs.com) backend using [Drizzle ORM](https://orm.drizzle.team)
-over PostgreSQL, and a [Next.js](https://nextjs.org) App Router frontend. It takes the artifacts
-produced by [`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) — the entity model, use
-case specifications, and test cases — and turns them into schema migrations, a REST API, a
-Next.js UI, and a full test suite across both halves of the stack.
+This plugin is designed to continue from the specifications produced by `aiup-core`. For the complete AIUP workflow,
+use it alongside `aiup-core` and select one stack plugin.
 
-Like the Angular/JPA plugin and unlike a server-rendered UI framework, this is a **split
-client/server architecture**: the backend and frontend are independent builds that share only a
-JSON contract over HTTP. Every skill in this plugin reflects that split.
+## Architecture support
 
-## What makes this plugin different
+The plugin supports a split client/server architecture whose applications share a JSON contract. It detects app
+roots, workspace structure, routing conventions, existing fetch clients, and package settings before writing code.
 
-This is the marketplace's first **TypeScript-native** stack: both halves run the same language,
-the same test runner, and the same package manager. That sounds simpler than the JVM and .NET
-plugins, and in most respects it is — but it introduces two failure modes those stacks do not
-have, and both are silent:
+Two TypeScript-specific concerns are handled explicitly:
 
-- **ESM / NodeNext import specifiers.** A NestJS backend on `"type": "module"` with
-  `"module": "NodeNext"` requires a `.js` suffix on every relative import *even though the source
-  file is `.ts`*. Omit it and nothing compiles; add it in a project that isn't NodeNext and
-  nothing compiles either. The skills detect which shape the project is before writing a single
-  import.
-- **Decorator metadata under Vitest.** NestJS dependency injection reads `design:paramtypes`
-  metadata that Vitest's default transformer does not emit. Without `unplugin-swc`, every provider
-  fails to resolve with an error that names a parameter index rather than the cause — and on Vite
-  8, where Oxc became the default transformer, it silently breaks again even *with*
-  `unplugin-swc` installed unless `oxc: false` is also set.
+- NestJS projects using ESM and NodeNext require `.js` suffixes on relative imports even when the source files are
+  TypeScript; projects using other module settings must not receive those suffixes.
+- NestJS dependency injection requires decorator metadata. Vitest configurations need an appropriate transformer,
+  including `unplugin-swc` and the applicable Vite/Oxc setting, to preserve that metadata.
 
-Encoding those two is most of why this plugin exists. The rest is keeping the layers where they
-belong: all SQL in repositories, no raw database rows in responses, and relative `/api` paths so
-the frontend never hardcodes a backend origin.
+The shared layout detection is documented in
+[`skills/implement/references/project-layout.md`](skills/implement/references/project-layout.md).
 
-## What it does
+## Skills and workflow
 
-This plugin covers the **Construction** phase of the AI Unified Process for the NestJS/Next.js
-stack: schema migrations, backend and frontend implementation, and testing on both sides — with
-every artifact traceable back to a use case (`UC-*`).
+| Phase        | Skill                                                     | Result                                                             |
+|--------------|-----------------------------------------------------------|--------------------------------------------------------------------|
+| Construction | [`/drizzle-migration`](skills/drizzle-migration/SKILL.md) | Drizzle schema changes and generated PostgreSQL migrations         |
+| Construction | [`/implement`](skills/implement/SKILL.md)                 | NestJS feature module and Next.js page                             |
+| Construction | [`/nest-test`](skills/nest-test/SKILL.md)                 | Vitest unit tests and Supertest tests on Testcontainers PostgreSQL |
+| Construction | [`/react-test`](skills/react-test/SKILL.md)               | React Testing Library component tests                              |
+| Construction | [`/playwright-test`](skills/playwright-test/SKILL.md)     | Browser journeys derived from `UC-*` or `TC-*` artifacts           |
 
-It is meant to be used **together with `ai-unified-process/aiup-core`**, which produces the upstream
-`docs/entity_model.md`, `docs/use_cases/UC-*.md`, and `docs/test_cases/TC-*.md` artifacts these
-skills read. Install exactly one stack plugin — this one is **not** meant to be used alongside
-`ai-unified-process/aiup-vaadin-jooq`, `ai-unified-process/aiup-angular-jpa`, or `ai-unified-process/aiup-blazor-dotnet`.
-
-## Skills
-
-Each skill is also available as a slash command.
-
-| Phase        | Skill / command      | Description                                                            |
-|--------------|----------------------|------------------------------------------------------------------------|
-| Construction | `/drizzle-migration` | Edit the Drizzle schema from the entity model and generate the SQL     |
-| Construction | `/implement`         | Implement a use case across the NestJS API and the Next.js frontend    |
-| Construction | `/nest-test`         | Vitest unit specs and Supertest e2e specs on Testcontainers PostgreSQL |
-| Construction | `/react-test`        | Vitest + React Testing Library component tests                        |
-| Construction | `/playwright-test`   | Playwright browser end-to-end tests, driven by `TC-*.md` where present |
-
-### Workflow
-
-```
+```text
 Construction
 ──────────────────────────────────────────────────────
 /drizzle-migration  →  /implement  →  /nest-test
@@ -69,67 +40,90 @@ Construction
                                    ↘  /playwright-test
 ```
 
-All five skills read the AI Unified Process artifacts under `docs/` and share one layout-detection reference,
-[`skills/implement/references/project-layout.md`](skills/implement/references/project-layout.md),
-which resolves where the two applications live and which conventions the project already follows
-before any code is written.
-
-## MCP servers
-
-| Server     | Purpose                                     |
-|------------|---------------------------------------------|
-| Playwright | Browser automation for end-to-end tests     |
-
-NestJS, Drizzle, Next.js, React, Vitest, Supertest and Testcontainers documentation is already
-covered by `aiup-core`'s **context7** MCP server, which resolves docs for any npm package on
-demand. See [`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
+The linked `SKILL.md` files are the authoritative reference for detailed inputs, outputs, and behavior.
 
 ## Installation
 
-Install from the Tessl registry (install the core plugin too, if you haven't already):
+### Tessl
 
+Initialize the project once:
+
+```sh
+tessl init --agent agents
 ```
+
+`agents` is the vendor-neutral layout; use `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode`
+for a specific host. Then install the plugins:
+
+```sh
 tessl install ai-unified-process/aiup-core
 tessl install ai-unified-process/aiup-nestjs-nextjs
 ```
 
+Depending on the configured agent, skills may be exposed as slash commands or invoked by intent, for example
+"implement UC-001".
+
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
+/plugin install aiup-nestjs-nextjs
+```
+
+See the marketplace [installation guides](../docs/getting-started.md) for other agents and manual adoption.
+
 ## Prerequisites
 
-- [`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) installed, with an entity model and
-  use case specifications already produced under `docs/`
-- A NestJS backend using Drizzle ORM over PostgreSQL, with `drizzle.config.ts` present
-- A Next.js frontend using the App Router
-- Docker running, for the Testcontainers-backed e2e tests
-- Optional Playwright MCP server configured per [`rules/mcp-servers.md`](rules/mcp-servers.md)
+- `aiup-core` and reviewed `docs/entity_model.md` plus `docs/use_cases/UC-*.md` artifacts.
+- A NestJS backend using Drizzle ORM over PostgreSQL with `drizzle.config.ts` present.
+- A Next.js frontend using the App Router.
+- Docker for Testcontainers-backed backend tests.
+- Optional Playwright MCP configuration described in [`rules/mcp-servers.md`](rules/mcp-servers.md).
+
+## Inputs and generated artifacts
+
+The plugin consumes the core artifacts under `docs/`, edits the configured Drizzle schema, generates migration
+history, creates backend and frontend feature code, and places tests according to the detected project conventions.
+`/playwright-test TC-XXX` additionally reads the matching test journey under `docs/test_cases/`.
 
 ## Project structure
 
-```
+```text
 your-project/
 ├── docs/
 │   ├── entity_model.md
 │   ├── use_cases/UC-*.md
 │   └── test_cases/TC-*.md
 ├── apps/api/
-│   ├── src/database/schema.ts        ← edited by /drizzle-migration
-│   ├── drizzle/migrations/           ← generated by /drizzle-migration
-│   ├── src/<feature>/                ← produced by /implement
-│   │   ├── <feature>.module.ts
-│   │   ├── <feature>.controller.ts
-│   │   ├── <feature>.service.ts
-│   │   ├── <feature>.repository.ts
-│   │   └── dto/
-│   ├── src/**/*.spec.ts              ← produced by /nest-test (unit)
-│   └── test/**/*.e2e-spec.ts         ← produced by /nest-test (e2e)
+│   ├── src/database/schema.ts            # /drizzle-migration
+│   ├── drizzle/migrations/               # generated migrations
+│   ├── src/<feature>/                    # /implement
+│   ├── src/**/*.spec.ts                  # /nest-test unit tests
+│   └── test/**/*.e2e-spec.ts             # /nest-test API tests
 └── apps/web/
-    ├── src/app/<route>/page.tsx      ← produced by /implement
-    ├── src/**/*.test.tsx             ← produced by /react-test
-    └── e2e/*.spec.ts                 ← produced by /playwright-test
+    ├── src/app/<route>/page.tsx          # /implement
+    ├── src/**/*.test.tsx                 # /react-test
+    └── e2e/*.spec.ts                     # /playwright-test
 ```
 
-**This layout is detected, not required.** A project with different app locations, no workspace
-split, or its page components behind a `views/` indirection works fine — the skills read the
-project's own conventions and follow them rather than imposing the shape above.
+This layout is detected, not required. Separate repositories, different workspace roots, and delegated view
+components are supported when the existing project establishes those conventions.
+
+## MCP servers
+
+| Server       | Purpose            |
+|--------------|--------------------|
+| `playwright` | Browser automation |
+
+NestJS, Drizzle, Next.js, React, Vitest, Supertest, and Testcontainers documentation is available through
+`aiup-core`'s `context7` server. See [`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
+
+## Related documentation
+
+- [Getting started](../docs/getting-started.md)
+- [Workflow and artifacts](../docs/workflow.md)
+- [`aiup-core`](../aiup-core/)
 
 ## License
 

--- a/aiup-nestjs-nextjs/plugin.json
+++ b/aiup-nestjs-nextjs/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aiup-nestjs-nextjs",
-  "version": "0.1.0",
-  "description": "AI Unified Process plugin for the NestJS/Drizzle + Next.js stack",
+  "version": "0.1.1",
+  "description": "AI Unified Process for the NestJS/Drizzle + Next.js stack - migrations, implementation, tests",
   "author": {
     "name": "Swift Ugandan",
     "email": "swiftugandan@gmail.com",

--- a/aiup-vaadin-jooq/.claude-plugin/plugin.json
+++ b/aiup-vaadin-jooq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aiup-vaadin-jooq",
-  "description": "AI Unified Process plugin for the Vaadin/jOOQ stack",
-  "version": "2.12.1",
+  "description": "AI Unified Process for the Vaadin/jOOQ stack - migrations, implementation, tests",
+  "version": "2.12.2",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/aiup-vaadin-jooq/.tessl-plugin/plugin.json
+++ b/aiup-vaadin-jooq/.tessl-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-unified-process/aiup-vaadin-jooq",
-  "description": "AI Unified Process plugin for the Vaadin/jOOQ stack",
-  "version": "2.12.1",
+  "description": "AI Unified Process for the Vaadin/jOOQ stack - migrations, implementation, tests",
+  "version": "2.12.2",
   "rules": "rules",
   "author": {
     "name": "Simon Martinelli",

--- a/aiup-vaadin-jooq/README.md
+++ b/aiup-vaadin-jooq/README.md
@@ -1,77 +1,121 @@
 # aiup-vaadin-jooq
 
-> The Vaadin + jOOQ stack plugin for the [**AI Unified Process (AIUP)**](https://unifiedprocess.ai) — turns use case
-> specifications into implemented, tested Java code.
+`aiup-vaadin-jooq` is the AIUP construction plugin for applications built with
+[Vaadin](https://vaadin.com) or Hilla and [jOOQ](https://www.jooq.org). It turns the entity model and use case
+specifications produced by [`aiup-core`](../aiup-core/) into migrations, application code, and tests.
 
-`aiup-vaadin-jooq` is the **technology-specific** layer of the AI Unified Process for applications built with
-[Vaadin](https://vaadin.com) (UI) and [jOOQ](https://www.jooq.org) (data access). It takes the artifacts produced by
-[`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) — the entity model and use case specifications — and turns
-them into database migrations, Vaadin views, jOOQ queries, and a full test suite.
+This plugin is designed to continue from the specifications produced by `aiup-core`. For the complete AIUP workflow,
+use it alongside `aiup-core` and select one stack plugin.
 
-## What it does
+## Skills and workflow
 
-This plugin covers the **Construction** phase of the AI Unified Process for the Vaadin/jOOQ stack: schema migrations,
-implementation, and testing — with every artifact traceable back to a use case (`UC-*`).
+| Phase        | Skill                                                   | Result                                                             |
+|--------------|---------------------------------------------------------|--------------------------------------------------------------------|
+| Construction | [`/flyway-migration`](skills/flyway-migration/SKILL.md) | Versioned Flyway migrations derived from the entity model          |
+| Construction | [`/implement`](skills/implement/SKILL.md)               | Vaadin Flow views and jOOQ data access                             |
+| Construction | [`/implement-hilla`](skills/implement-hilla/SKILL.md)   | Hilla React views, browser-callable services, and jOOQ data access |
+| Construction | [`/browserless-test`](skills/browserless-test/SKILL.md) | Vaadin Browserless server-side tests; recommended for new work     |
+| Construction | [`/karibu-test`](skills/karibu-test/SKILL.md)           | Karibu server-side tests for existing Karibu projects              |
+| Construction | [`/playwright-test`](skills/playwright-test/SKILL.md)   | Playwright tests using Drama Finder for `UC-*` or `TC-*` artifacts |
 
-It is meant to be used **together with `ai-unified-process/aiup-core`**, which produces the upstream `docs/entity_model.md` and
-`docs/use_cases/UC-*.md` artifacts these skills read.
-
-## Skills
-
-Each skill is also available as a slash command.
-
-| Phase        | Skill / command       | Description                                                              |
-|--------------|-----------------------|--------------------------------------------------------------------------|
-| Construction | `/flyway-migration`   | Create versioned Flyway migration scripts (`V*.sql`) from the entity model |
-| Construction | `/implement`          | Implement use cases as Vaadin Flow views/forms/grids plus jOOQ data access |
-| Construction | `/implement-hilla`    | Implement use cases as Hilla views (React + `@BrowserCallable`) plus jOOQ data access |
-| Construction | `/browserless-test`   | Create Vaadin Browserless server-side unit tests (recommended)           |
-| Construction | `/karibu-test`        | Create Karibu server-side unit tests (legacy — superseded since Vaadin 25.1) |
-| Construction | `/playwright-test`    | Create Playwright browser-based tests (Drama Finder) — use case integration tests (UC-*) or end-to-end test case journeys (TC-*) |
-
-### Workflow
-
-```
+```text
 Construction
-────────────────────────────────────────────────────
+─────────────────────────────────────────────────────────────────────
 /flyway-migration  →  /implement  →  /browserless-test
                                   ↘  /playwright-test  (UC-* or TC-*)
 ```
 
-Use `/implement` for Vaadin Flow (server-side Java) views and `/implement-hilla` for Hilla
-(React/TypeScript) views — both share the same jOOQ data access conventions.
+Use `/implement-hilla` instead of `/implement` for Hilla. Since Vaadin 25.1, Browserless Testing is the recommended
+server-side option; `/karibu-test` remains available for codebases that already use Karibu.
 
-These skills read the AI Unified Process artifacts under `docs/` (`docs/entity_model.md`, `docs/use_cases/UC-*.md`, and
-`docs/test_cases/TC-*.md`) produced by `ai-unified-process/aiup-core` and write code and tests into your Maven/Gradle project.
-
-## MCP servers
-
-The plugin wires up MCP servers that give the skills authoritative, version-correct knowledge of the stack. Some are
-optional — see [`rules/mcp-servers.md`](rules/mcp-servers.md) for setup details.
-
-| Server         | Purpose                                                          |
-|----------------|------------------------------------------------------------------|
-| Vaadin         | Vaadin component APIs, docs, and theming (version-aware)         |
-| KaribuTesting  | Karibu server-side test generation and migration helpers        |
-| jOOQ           | jOOQ query DSL reference, code generation, and SQL examples      |
-| JavaDocs       | Javadoc lookup for libraries on the classpath                    |
-| Playwright     | Browser automation for end-to-end tests                          |
+The linked `SKILL.md` files are the authoritative reference for detailed inputs, outputs, and behavior.
 
 ## Installation
 
-Install from the Tessl registry (install the core plugin too, if you haven't already):
+### Tessl
 
+Initialize the project once:
+
+```sh
+tessl init --agent agents
 ```
+
+`agents` is the vendor-neutral layout; use `claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode`
+for a specific host. Then install the plugins:
+
+```sh
 tessl install ai-unified-process/aiup-core
 tessl install ai-unified-process/aiup-vaadin-jooq
 ```
 
+Depending on the configured agent, skills may be exposed as slash commands or invoked by intent, for example
+"implement UC-001".
+
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
+/plugin install aiup-vaadin-jooq
+```
+
+See the marketplace [installation guides](../docs/getting-started.md) for other agents and manual adoption.
+
 ## Prerequisites
 
-- [`ai-unified-process/aiup-core`](https://registry.tessl.io/ai-unified-process/aiup-core) installed, with use case specifications and an entity
-  model already produced under `docs/`
-- A Maven or Gradle project with Vaadin and jOOQ on the classpath
-- Optional MCP servers (Vaadin, jOOQ, etc.) configured per [`rules/mcp-servers.md`](rules/mcp-servers.md)
+- `aiup-core` and reviewed `docs/entity_model.md` plus `docs/use_cases/UC-*.md` artifacts.
+- A Maven or Gradle project with Vaadin and jOOQ on the classpath.
+- Optional MCP servers configured as described in [`rules/mcp-servers.md`](rules/mcp-servers.md).
+- A running application for browser-based Playwright tests.
+
+## Inputs and generated artifacts
+
+Migration and implementation skills consume the entity model and individual use case specifications. A
+`/playwright-test TC-XXX` journey additionally consumes `docs/test_cases/TC-*.md`.
+
+The plugin writes Flyway migrations, Vaadin or Hilla implementation classes, server-side tests, and browser tests into
+the target project's existing Maven or Gradle layout.
+
+## Project structure
+
+The common Vaadin Flow layout is:
+
+```text
+your-project/
+├── docs/
+│   ├── entity_model.md
+│   ├── use_cases/UC-*.md
+│   └── test_cases/TC-*.md
+└── src/
+    ├── main/
+    │   ├── java/                         # /implement
+    │   ├── frontend/views/               # /implement-hilla
+    │   └── resources/db/migration/       # /flyway-migration
+    └── test/
+        ├── java/                         # server-side and Playwright tests
+        └── resources/db/migration/       # test data seeds
+```
+
+The skills inspect the existing code and build files before choosing packages and paths; the tree above is illustrative,
+not a required project skeleton.
+
+## MCP servers
+
+| Server          | Purpose                                              |
+|-----------------|------------------------------------------------------|
+| `Vaadin`        | Component APIs, framework documentation, and theming |
+| `KaribuTesting` | Karibu test APIs and migration guidance              |
+| `jOOQ`          | Query DSL, code generation, and SQL references       |
+| `JavaDocs`      | Java APIs available on the project classpath         |
+| `playwright`    | Browser automation                                   |
+
+See [`rules/mcp-servers.md`](rules/mcp-servers.md) for optional-server behavior and setup details.
+
+## Related documentation
+
+- [Getting started](../docs/getting-started.md)
+- [Workflow and artifacts](../docs/workflow.md)
+- [`aiup-core`](../aiup-core/)
 
 ## License
 

--- a/aiup-vaadin-jooq/plugin.json
+++ b/aiup-vaadin-jooq/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aiup-vaadin-jooq",
-  "version": "2.12.1",
-  "description": "AI Unified Process plugin for the Vaadin/jOOQ stack",
+  "version": "2.12.2",
+  "description": "AI Unified Process for the Vaadin/jOOQ stack - migrations, implementation, tests",
   "author": {
     "name": "Simon Martinelli",
     "email": "simon@martinelli.ch",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,116 @@
+# Getting started
+
+AI Unified Process (AIUP) turns a product vision into reviewed specifications, implementation, and traceable tests.
+Use `aiup-core` for the stack-independent analysis workflow and add exactly one stack plugin for implementation.
+
+## 1. Choose your plugins
+
+Every project needs `aiup-core`. Add the plugin that matches the application's implementation stack.
+
+| Plugin                                         | Use it for                                                                    |
+|------------------------------------------------|-------------------------------------------------------------------------------|
+| [`aiup-core`](../aiup-core/)                   | Requirements, entity model, use cases, test journeys, and reverse engineering |
+| [`aiup-vaadin-jooq`](../aiup-vaadin-jooq/)     | Vaadin Flow or Hilla with jOOQ                                                |
+| [`aiup-angular-jpa`](../aiup-angular-jpa/)     | Angular with a Spring Boot/JPA backend                                        |
+| [`aiup-blazor-dotnet`](../aiup-blazor-dotnet/) | Blazor and EF Core on .NET 10                                                 |
+| [`aiup-nestjs-nextjs`](../aiup-nestjs-nextjs/) | NestJS/Drizzle and Next.js App Router                                         |
+
+Install only `aiup-core` when you want to use the analysis workflow with an unsupported implementation stack.
+
+## 2. Prepare the product vision
+
+Create `docs/vision.md` in the project where AIUP will run. Describe the problem, target users, goals, scope, and
+constraints. Start from the [vision template](templates/vision.md) if the project does not have one yet.
+
+The quality of the requirements catalog depends on the quality of this input. Prefer concrete goals and explicit
+non-goals over a long feature wish list.
+
+## 3. Install the plugins
+
+### Claude Code
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+/plugin install aiup-core
+/plugin install aiup-vaadin-jooq
+```
+
+Replace `aiup-vaadin-jooq` with the selected stack plugin. See the full
+[Claude Code installation guide](installation/claude-code.md).
+
+### Tessl
+
+```sh
+tessl init --agent agents
+tessl install ai-unified-process/aiup-core
+tessl install ai-unified-process/aiup-vaadin-jooq
+```
+
+Tessl can configure several supported coding agents and pins installed versions in `tessl.json`. See the full
+[Tessl installation guide](installation/tessl.md). Replace the vendor-neutral `agents` identifier with
+`claude-code`, `cursor`, `gemini`, `codex`, `copilot`, or `copilot-vscode` when configuring a specific host layout.
+
+For direct Agent Plugins adoption or manual setup in Codex, Cursor, Copilot, Gemini CLI, and OpenCode, see
+[Agent Plugins and manual installation](installation/other-agents.md).
+
+## 4. Run the core workflow
+
+Start the coding agent in the target project and create the analysis artifacts in order:
+
+```text
+/requirements
+/entity-model
+/use-case-diagram
+/use-case-spec UC-001
+```
+
+Review every generated file before continuing. The artifacts are deliberately plain Markdown, Mermaid, and PlantUML
+so a team can correct them in version control without running a skill again.
+
+The core workflow produces:
+
+```text
+docs/
+├── vision.md
+├── requirements.md
+├── entity_model.md
+├── use_cases.puml
+└── use_cases/
+    └── UC-001-*.md
+```
+
+If the agent starts by reading `docs/vision.md` after `/requirements`, the core plugin is available. If the command is
+not exposed as a slash command by the selected agent, ask it to "generate the requirements catalog from the product
+vision"; Agent Skills can also be activated by intent.
+
+## 5. Implement and test
+
+Once a use case specification exists, continue with the commands from the selected stack plugin. For example, the
+construction workflow normally consists of a migration, `/implement UC-001`, stack-specific unit or integration tests,
+and `/playwright-test UC-001`.
+
+For a journey across several use cases, first create a test-case document:
+
+```text
+/test-case UC-001 UC-004
+/playwright-test TC-001
+```
+
+The exact commands, prerequisites, generated paths, and testing conventions are documented in each plugin README.
+The complete artifact lifecycle is described in [Workflow and artifacts](workflow.md).
+
+## Existing projects
+
+When a project already contains working code but lacks AIUP documents, start with:
+
+```text
+/reverse-engineer
+```
+
+The skill recovers an entity model, use case diagram, and use case specifications from the codebase. Review the
+reported gaps before using those artifacts as the baseline for further work.
+
+## Complete example
+
+The [Book Library tutorial](https://unifiedprocess.ai/tutorial.html) demonstrates the complete workflow. Its first
+five steps are stack-independent; steps six through nine use the Vaadin and jOOQ plugin for construction and testing.

--- a/docs/guides/project-setup.md
+++ b/docs/guides/project-setup.md
@@ -1,0 +1,57 @@
+# Project setup
+
+AIUP keeps product and analysis artifacts in a `docs/` directory committed alongside the implementation. The source
+layout depends on the selected stack plugin, but the documentation contract stays the same.
+
+## Documentation tree
+
+```text
+your-project/
+├── docs/
+│   ├── vision.md
+│   ├── requirements.md
+│   ├── entity_model.md
+│   ├── use_cases.puml
+│   ├── use_cases/
+│   │   ├── UC-001-*.md
+│   │   └── ...
+│   └── test_cases/
+│       ├── TC-001-*.md
+│       └── ...
+└── agent instruction file
+```
+
+`docs/vision.md` is maintained by the team. The other files are initially produced by AIUP skills and then reviewed
+like any other project artifact. Commit them so identifiers, decisions, and generated code can be traced together.
+
+Stack-specific source and test trees are documented in the plugin READMEs:
+
+- [Vaadin and jOOQ](../../aiup-vaadin-jooq/)
+- [Angular and JPA](../../aiup-angular-jpa/)
+- [Blazor and .NET](../../aiup-blazor-dotnet/)
+- [NestJS and Next.js](../../aiup-nestjs-nextjs/)
+
+## Product vision
+
+Start with the [vision template](../templates/vision.md). Include the product mission, target users, measurable goals,
+scope boundaries, and technical, regulatory, or organizational constraints.
+
+Avoid encoding a complete solution design in the vision. The requirements and entity-model steps should be able to
+derive and challenge the design from user goals and constraints.
+
+## Agent instructions
+
+Most coding agents support a repository instruction file. Use the format appropriate to the host and tell the agent to
+read the AIUP artifacts before making product or architecture decisions.
+
+For Claude Code, copy the [CLAUDE.md template](../templates/CLAUDE.md) to the project root. For another host, adapt the
+same rules to its instruction-file convention. Keep the shared instructions stack-neutral; put stack-specific build,
+test, and architecture conventions in the project's existing guidance or link to the selected plugin README.
+
+## Maintenance rules
+
+- Review generated documents between workflow steps.
+- Keep requirement, use case, and test case identifiers stable after publication.
+- Update downstream artifacts when an upstream decision changes.
+- Preserve explicit non-goals and constraints; they prevent regenerated code from silently expanding scope.
+- Do not treat generated documentation as disposable build output.

--- a/docs/installation/claude-code.md
+++ b/docs/installation/claude-code.md
@@ -1,0 +1,60 @@
+# Install with Claude Code
+
+Claude Code can install AIUP directly from the marketplace. Install `aiup-core` in every project and add exactly one
+stack plugin when the implementation stack is supported.
+
+## Prerequisites
+
+- Claude Code is installed and can open the target project.
+- The target project contains a `docs/vision.md` file for the forward workflow, or existing code for
+  `/reverse-engineer`.
+- Stack-specific prerequisites from the selected plugin README are available.
+
+## Add the marketplace
+
+Run this once in Claude Code:
+
+```text
+/plugin marketplace add ai-unified-process/marketplace
+```
+
+## Install plugins
+
+Install the core plugin:
+
+```text
+/plugin install aiup-core
+```
+
+Then install one matching stack plugin:
+
+```text
+/plugin install aiup-vaadin-jooq
+/plugin install aiup-angular-jpa
+/plugin install aiup-blazor-dotnet
+/plugin install aiup-nestjs-nextjs
+```
+
+The four commands above are alternatives, not a bundle. Projects on another stack need only `aiup-core` and can use
+their own implementation workflow after the specification boundary.
+
+## Verify the installation
+
+Start Claude Code in the target project and run:
+
+```text
+/requirements
+```
+
+The skill should read `docs/vision.md` and propose a requirements catalog. Existing applications without a vision
+document can start with `/reverse-engineer`, but that skill is not a non-mutating installation check: it creates an
+entity model, use case diagram, and use case specifications under `docs/`. Review those artifacts after it completes.
+
+## Update or change the stack plugin
+
+Keep the core plugin installed when changing the implementation stack. Remove the old stack plugin through Claude
+Code's plugin management and install the new one; do not keep multiple plugins that expose the same construction
+commands in one project.
+
+Continue with [Getting started](../getting-started.md) or consult the selected plugin README for its prerequisites and
+construction workflow.

--- a/docs/installation/other-agents.md
+++ b/docs/installation/other-agents.md
@@ -1,0 +1,133 @@
+# Agent Plugins and manual installation
+
+AIUP is a methodology implemented as portable Agent Skills. Every plugin directory is also an
+[Agent Plugins](https://agent-plugins.org) package with a root `plugin.json`, `mcp.json`, and `skills/` directory.
+Clients that implement the standard can load a plugin directly from a checkout of this repository.
+
+For most supported agents, [Tessl](tessl.md) is the shortest installation path. Use this page when adopting the
+packages directly or configuring skills and MCP servers by hand.
+
+## What is portable
+
+| Component           | Portability   | Notes                                                                     |
+|---------------------|---------------|---------------------------------------------------------------------------|
+| `skills/*/SKILL.md` | Portable      | Conforms to the Agent Skills layout and can be invoked by intent          |
+| `plugin.json`       | Portable      | Agent Plugins v1.0.0 package manifest                                     |
+| `mcp.json`          | Portable      | Agent Plugins MCP definitions; host configuration shapes may differ       |
+| AIUP artifacts      | Portable      | Markdown, Mermaid, and PlantUML files are the contract between steps      |
+| Slash commands      | Host-specific | If `/command` routing is unavailable, state the same intent in the prompt |
+
+## Load an Agent Plugins package
+
+Clone the repository and point an Agent Plugins-conformant client at `aiup-core` plus one stack directory:
+
+```sh
+git clone https://github.com/AI-Unified-Process/marketplace.git
+```
+
+The manifests are validated against the Claude Code and Tessl variants in CI. Consult the client's documentation for
+the command or UI used to add a local package.
+
+## Manual installation
+
+Without an Agent Plugins loader:
+
+1. Clone this repository next to the target project or add it as a submodule.
+2. Copy or symlink the skill folders from `aiup-core/skills/` and one stack plugin's `skills/` into the location
+   scanned by the coding agent.
+3. Translate the MCP servers from the plugins' `mcp.json` into the host's MCP configuration.
+4. Start the agent in the target project and ask it to generate requirements from `docs/vision.md`.
+
+Install whole skill directories, not only their `SKILL.md` files. Some skills also use bundled references and scripts.
+
+## OpenAI Codex
+
+Codex discovers repository skills from `.agents/skills/` between the current working directory and repository root,
+and user-level skills from `$HOME/.agents/skills/`. It supports symlinked skill directories. For example:
+
+```sh
+mkdir -p .agents/skills
+ln -s /path/to/marketplace/aiup-core/skills/requirements .agents/skills/requirements
+```
+
+Configure MCP servers in `~/.codex/config.toml`, or use a trusted project's `.codex/config.toml` for project-scoped
+configuration:
+
+```toml
+[mcp_servers.Vaadin]
+url = "https://mcp.vaadin.com/docs"
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]
+```
+
+See the official OpenAI documentation for
+[building Codex skills](https://developers.openai.com/codex/build-skills) and the
+[Codex configuration reference](https://developers.openai.com/codex/config-reference).
+
+## Cursor
+
+Place project skills under `.cursor/skills/` or `.agents/skills/`. For skills that should be available to the user in
+every project, use `~/.cursor/skills/` or `~/.agents/skills/`. Cursor also recognizes the compatible `.claude/skills/`
+and `.codex/skills/` layouts. Configure MCP servers in the project's `.cursor/mcp.json` or the user's Cursor MCP
+configuration. HTTP definitions use a URL; local servers use a command and arguments.
+
+## GitHub Copilot
+
+Copilot can discover skills from repository locations including `.github/skills/`, `.claude/skills/`, and
+`.agents/skills/`. For a manual MCP setup in VS Code, place shared server definitions in `.vscode/mcp.json`:
+
+```jsonc
+{
+  "servers": {
+    "Vaadin": { "type": "http", "url": "https://mcp.vaadin.com/docs" },
+    "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] }
+  }
+}
+```
+
+Copilot environments that support Claude Code plugin marketplaces can alternatively use the commands from the
+[Claude Code installation guide](claude-code.md).
+
+## Gemini CLI
+
+Place skills under `.gemini/skills/` in the project or the corresponding user-level directory. Gemini's
+`mcpServers` settings use the familiar URL or command-and-arguments shape, so the plugin MCP definitions require only
+minor translation.
+
+## OpenCode
+
+Place skills under `.opencode/skills/` in the project or the configured user skill directory. OpenCode also scans
+common `.claude/skills/` and `.agents/skills/` layouts. Its `opencode.json` uses `type: "remote"` with a URL for HTTP
+servers and `type: "local"` with a command array for local servers:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "Vaadin": {
+      "type": "remote",
+      "url": "https://mcp.vaadin.com/docs"
+    },
+    "playwright": {
+      "type": "local",
+      "command": [
+        "npx",
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}
+```
+
+## Invocation differences
+
+- When slash commands are unavailable, say "specify UC-001", "implement UC-001", or "test TC-001". The agent can
+  match the request to a skill's description.
+- Pass identifiers in the chat message when the host does not support positional slash-command arguments.
+- HTTP MCP is not supported by every client. A stdio-only client needs an HTTP-to-stdio bridge for remote servers.
+- The files under `docs/` remain compatible even when different steps are run by different agents.
+
+Host capabilities and configuration paths evolve independently. Check the host's current documentation if its layout
+differs from the examples above.

--- a/docs/installation/tessl.md
+++ b/docs/installation/tessl.md
@@ -1,0 +1,53 @@
+# Install with Tessl
+
+[Tessl](https://tessl.io) installs versioned AIUP plugins for supported coding agents and records them in the
+project's `tessl.json` manifest.
+
+## Initialize the project
+
+From the target project, configure one or more agents:
+
+```sh
+tessl init --agent agents
+```
+
+Use the agent identifier supported by your Tessl version, such as `claude-code`, `cursor`, `gemini`, `codex`,
+`copilot`, `copilot-vscode`, or the vendor-neutral `agents` layout. Repeat `--agent` when configuring several agents.
+
+## Install plugins
+
+Install `aiup-core` and one stack plugin:
+
+```sh
+tessl install ai-unified-process/aiup-core
+tessl install ai-unified-process/aiup-vaadin-jooq
+```
+
+Available stack packages are:
+
+```text
+ai-unified-process/aiup-vaadin-jooq
+ai-unified-process/aiup-angular-jpa
+ai-unified-process/aiup-blazor-dotnet
+ai-unified-process/aiup-nestjs-nextjs
+```
+
+Use only `aiup-core` for an unsupported implementation stack. Use only one of the four stack packages in a project.
+
+## Versions and team use
+
+Installed plugins live under `.tessl/plugins/` and are tracked by `tessl.json`. Commit the manifest so every team
+member installs the same versions. A package can be pinned explicitly with Tessl's `@version` syntax when the team does
+not want automatic resolution to a newer release.
+
+Tessl maps skills and MCP configuration into the selected agent layouts. Slash-command behavior can still differ
+between hosts; when a command is not exposed, invoke the skill by intent, for example "implement UC-001".
+
+## Verify the installation
+
+Open the configured agent in the target project and request the requirements catalog. The agent should discover the
+AIUP requirements skill and read `docs/vision.md`. If it does not, inspect `tessl.json`, confirm that the configured
+agent matches the one being run, and rerun the Tessl installation.
+
+Continue with [Getting started](../getting-started.md). For manual layouts and host-specific MCP examples, see
+[Agent Plugins and manual installation](other-agents.md).

--- a/docs/templates/CLAUDE.md
+++ b/docs/templates/CLAUDE.md
@@ -1,0 +1,22 @@
+# Project context
+
+This project follows the AI Unified Process. Before making product, domain, or architecture decisions, read:
+
+- `docs/vision.md`
+- `docs/requirements.md`
+- `docs/entity_model.md`
+- the relevant documents under `docs/use_cases/` and `docs/test_cases/`
+
+## Workflow rules
+
+1. Derive requirements from the product vision.
+2. Reconcile the entity model and use case diagram when requirements change.
+3. Do not implement a use case before its `UC-*.md` specification exists and has been reviewed.
+4. Keep requirement, use case, and test case identifiers stable and traceable in code and tests.
+5. Use the installed stack plugin for migrations, implementation, and testing.
+6. Review and preserve the conventions already established in the codebase.
+
+## Verification
+
+Run the project's documented build, static analysis, and test commands after implementation. Report any verification
+that could not be completed.

--- a/docs/templates/vision.md
+++ b/docs/templates/vision.md
@@ -1,0 +1,33 @@
+# Vision: {Product Name}
+
+## Mission
+
+{Describe the problem this product solves and the outcome it creates.}
+
+## Target users
+
+- {Primary user role and its main need}
+- {Secondary user role and its main need}
+
+## Goals
+
+- {Measurable product or business goal}
+- {Measurable quality or adoption goal}
+
+## Scope
+
+### In scope
+
+- {High-level capability}
+
+### Out of scope
+
+- {Explicit non-goal}
+
+## Constraints
+
+- {Technical, regulatory, business, or organizational constraint}
+
+## Success measures
+
+- {How the team will know that the product is successful}

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,82 @@
+# Workflow and artifacts
+
+The AI Unified Process is a requirements-first development workflow adapted from the phases of the
+[Rational Unified Process](https://en.wikipedia.org/wiki/Rational_unified_process). AIUP keeps product intent in
+versioned, human-reviewable artifacts that every later step consumes.
+
+## Workflow
+
+```text
+Inception          Elaboration                            Construction
+─────────────     ───────────────────────────────────     ─────────────────────────────────
+/requirements  →  /entity-model  →  /use-case-diagram  →  /use-case-spec  →  migration
+                                                                          ↘  implementation
+                                                                          ↘  tests
+```
+
+`aiup-core` owns the stack-independent steps. A stack plugin owns migrations, implementation, and tests. The boundary
+between them is the set of files under `docs/`, not a specific coding agent.
+
+## Artifact flow
+
+| Artifact                  | Produced by         | Consumed by                        |
+|---------------------------|---------------------|------------------------------------|
+| `docs/vision.md`          | Product team        | `/requirements`                    |
+| `docs/requirements.md`    | `/requirements`     | Entity model and use case diagram  |
+| `docs/entity_model.md`    | `/entity-model`     | Migrations and implementations     |
+| `docs/use_cases.puml`     | `/use-case-diagram` | `/use-case-spec` and reviewers     |
+| `docs/use_cases/UC-*.md`  | `/use-case-spec`    | Implementations and use case tests |
+| `docs/test_cases/TC-*.md` | `/test-case`        | End-to-end journey tests           |
+
+Every artifact is a review point. Correcting an intermediate document is expected and is safer than compensating for
+an incorrect assumption in generated code.
+
+## Traceability
+
+AIUP uses stable identifiers to preserve the path from intent to tests:
+
+- Functional requirements use `FR-XXX`; non-functional requirements use `NFR-XXX`; constraints use `C-XXX`.
+- Use cases use `UC-XXX` and reference the functional requirements they realize.
+- Test cases use `TC-XXX` and reference the use cases in their journey.
+- Generated tests retain the applicable `UC-*` or `TC-*` identifier in their name or metadata.
+
+Do not reuse an identifier for a different concern after it has been committed. When a requirement changes, update it
+and rerun or reconcile the downstream artifacts that depend on it.
+
+## Core skills
+
+| Skill                                                                | Result                                             |
+|----------------------------------------------------------------------|----------------------------------------------------|
+| [`/requirements`](../aiup-core/skills/requirements/SKILL.md)         | Requirements catalog derived from `docs/vision.md` |
+| [`/entity-model`](../aiup-core/skills/entity-model/SKILL.md)         | Mermaid entity model and attribute definitions     |
+| [`/use-case-diagram`](../aiup-core/skills/use-case-diagram/SKILL.md) | PlantUML diagram of actors and use cases           |
+| [`/use-case-spec`](../aiup-core/skills/use-case-spec/SKILL.md)       | One detailed specification per use case            |
+| [`/test-case`](../aiup-core/skills/test-case/SKILL.md)               | Executable user journey across specified use cases |
+| [`/reverse-engineer`](../aiup-core/skills/reverse-engineer/SKILL.md) | AIUP baseline recovered from an existing codebase  |
+
+The linked `SKILL.md` files are the authoritative descriptions of inputs, outputs, and behavior.
+
+## Working with changes
+
+When product intent changes:
+
+1. Update `docs/vision.md` or the relevant requirement.
+2. Reconcile `docs/requirements.md` and keep existing identifiers stable.
+3. Revisit the entity model and use case diagram if the domain or user goals changed.
+4. Update affected use case and test case documents.
+5. Reconcile migrations, implementation, and tests through the selected stack plugin.
+
+Commit `docs/` with the source code. These files explain why the implementation exists and make reviews, onboarding,
+and later regeneration reproducible.
+
+## Existing codebases
+
+`/reverse-engineer` inspects entry points, data models, authorization, and integrations to recover the same entity and
+use case artifacts produced by the forward workflow. It groups behavior by user goal rather than by endpoint and
+reports code it cannot classify. Treat the result as a proposed baseline: resolve gaps and contradictions before
+continuing with construction skills.
+
+## Project guidance
+
+Agent instruction files should tell the coding agent to read the AIUP artifacts before making product or architecture
+decisions. See [Project setup](guides/project-setup.md) for a generic project tree and reusable templates.

--- a/scripts/rewrite-plugin-readme-links.sh
+++ b/scripts/rewrite-plugin-readme-links.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Rewrite links that leave a plugin directory before publishing that directory as a standalone package.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <plugin-dir> <repository-url> <git-ref>" >&2
+  exit 2
+fi
+
+plugin_dir=$1
+repository_url=${2%/}
+git_ref=$3
+readme="$plugin_dir/README.md"
+registry_base="https://tessl.io/registry/ai-unified-process"
+
+if [ ! -f "$readme" ]; then
+  echo "ERROR: README not found: $readme" >&2
+  exit 1
+fi
+
+# Keep sibling-package links inside the Tessl registry. This must run before the
+# generic parent-relative rewrite below.
+REGISTRY_BASE="$registry_base" perl -pi -e 's{\]\(\.\./(aiup-[a-z0-9-]+)/?\)}{"](" . $ENV{REGISTRY_BASE} . "/$1)"}ge' "$readme"
+
+BASE="$repository_url" REF="$git_ref" perl -pi -e 's{\]\(\.\./([^)]+)\)}{
+  my $path = $1;
+  my $kind = ($path =~ m{\.md(?:#|$)}) ? "blob" : "tree";
+  "]($ENV{BASE}/$kind/$ENV{REF}/$path)"
+}ge' "$readme"
+
+if grep -q '](\.\./' "$readme"; then
+  echo "ERROR: unrewritten parent-relative link in $readme" >&2
+  exit 1
+fi

--- a/scripts/validate-doc-links.sh
+++ b/scripts/validate-doc-links.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Validate navigation links in the public marketplace documentation.
+#
+# Skill references and templates are intentionally outside this check: some contain example links whose base is the
+# generated project document rather than the SKILL.md source file and therefore need source-aware validation.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+error() {
+  echo "ERROR: $1" >&2
+  fail=$((fail + 1))
+}
+
+mapfile -t files < <(
+  find docs -type f -name '*.md' -print | sort
+  printf '%s\n' README.md aiup-*/README.md
+)
+
+for file in "${files[@]}"; do
+  while IFS= read -r -d '' line_number && IFS= read -r -d '' target; do
+    case "$target" in
+      http://*|https://*|mailto:*|\#*) continue ;;
+    esac
+
+    path=${target%%#*}
+    [ -n "$path" ] || continue
+
+    if [ ! -e "$(dirname "$file")/$path" ]; then
+      error "$file:$line_number: broken relative link: $target"
+    fi
+  done < <(perl -ne 'while (/\[[^\]]*\]\(([^)]+)\)/g) { print "$.", "\0", $1, "\0" }' "$file")
+done
+
+[ "$fail" -eq 0 ]

--- a/scripts/validate-plugin-manifests.sh
+++ b/scripts/validate-plugin-manifests.sh
@@ -17,12 +17,13 @@ for dir in aiup-*/; do
   root="$plugin/plugin.json"
   claude="$plugin/.claude-plugin/plugin.json"
   tessl="$plugin/.tessl-plugin/plugin.json"
+  marketplace=".claude-plugin/marketplace.json"
   root_mcp="$plugin/mcp.json"
   claude_mcp="$plugin/.mcp.json"
 
   fail_before=$fail
   missing=0
-  for f in "$root" "$claude" "$tessl" "$root_mcp" "$claude_mcp"; do
+  for f in "$root" "$claude" "$tessl" "$marketplace" "$root_mcp" "$claude_mcp"; do
     if [ ! -f "$f" ]; then
       error "$f is missing"
       missing=1
@@ -40,6 +41,15 @@ for dir in aiup-*/; do
   version=$(jq -r .version "$claude")
   [ "$(jq -r .version "$root")" = "$version" ] || error "version mismatch: $root has $(jq -r .version "$root"), $claude has $version"
   [ "$(jq -r .version "$tessl")" = "$version" ] || error "version mismatch: $tessl has $(jq -r .version "$tessl"), $claude has $version"
+
+  description=$(jq -r .description "$claude")
+  [ "$(jq -r .description "$root")" = "$description" ] || error "$root: description must match $claude"
+  [ "$(jq -r .description "$tessl")" = "$description" ] || error "$tessl: description must match $claude"
+
+  marketplace_count=$(jq --arg name "$name" '[.plugins[] | select(.name == $name)] | length' "$marketplace")
+  [ "$marketplace_count" -eq 1 ] || error "$marketplace: expected exactly one entry for $name"
+  marketplace_description=$(jq -r --arg name "$name" '.plugins[] | select(.name == $name) | .description' "$marketplace")
+  [ "$marketplace_description" = "$description" ] || error "$marketplace: description for $name must match $claude"
 
   # mcp.json must mirror .mcp.json, with Claude Code's "http" transport
   # expressed as the standard's "streamable-http".


### PR DESCRIPTION
## Summary

- streamline the root README into a concise entry point
- add dedicated guides for getting started, workflow, installation, and project setup
- standardize the README structure across all plugins
- add reusable project templates
- rewrite relative README links for Tessl publishing
- add CI validation for documentation and published plugin links
- align plugin versions and manifest descriptions

The changes are split into nine thematic commits for easier review.

## Validation

- `bash scripts/validate-doc-links.sh`
- `bash scripts/validate-plugin-manifests.sh`